### PR TITLE
Remove parser specification

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,6 +1,5 @@
 {
   "semi": false,
-  "parser": "babylon",
   "singleQuote": true,
   "trailingComma": "all"
 }


### PR DESCRIPTION
Setting the parser to babylon was useful many moons ago for something to do
with JSX.  This config was kept because there was never a reason to change it,
but it turns out that it doesn't parse json well which, mixed with husky
pre-commit hooks blocked me from commiting.  This fixes the issue by simply
removing the stated preference for babylon.