### PR TITLE
Initial Kubernetes config for API

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,7 @@
+**
+!src/
+!.env.example
+!index.js
+!package.json
+!package-lock.json
+!node_modules

--- a/api/.prettierrc
+++ b/api/.prettierrc
@@ -1,6 +1,5 @@
 {
   "semi": false,
-  "parser": "babylon",
   "singleQuote": true,
   "trailingComma": "all"
 }

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,6 +6,7 @@ ENV NODE_ENV production
 WORKDIR /app
 ADD . .
 
+USER node
 EXPOSE 3000
 CMD npm start
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,3 +1,44 @@
 # RCMP prototype API
 
-This is a simple hello world style API. Nothing to see here... yet.
+This is a simple hello world style API.
+
+### Running the API
+
+The API requires a few environmental variables to run. These are expected to be
+in a `.env` file, which you should create based on `.env.example`.
+
+With those in place and [ArangoDB](https://www.arangodb.com/) running, you can
+start the API in the standard way.
+
+```sh
+npm start
+```
+
+### Running the tests
+
+```sh
+npm test
+```
+
+### Deployment
+
+We are using Kubernetes to deploy the API, and the manifests describing the
+cluster config are in the `manifests` directory.
+
+We are using [Kustomize](https://github.com/kubernetes-sigs/kustomize) to
+generate platform/environment specific variations of our configuration.
+
+For example to get this going in
+[Minikube](https://github.com/kubernetes/minikube) you would do something like
+the following.
+
+```sh
+# start minikube with a non-resource hogging driver and lots of memory
+minikube start --vm-driver=kvm2 --memory=8096
+# create a secret for the root db password
+kubectl create secret generic arango-secrets --from-literal=ARANGO_ROOT_PASSWORD=soopersecret
+# create a secret from the env file
+kubectl create secret generic cybercrime-api --from-env-file=.env
+# generate the config and pipe it into kubectl
+kustomize build manifests/overlays/minikube/ | kubectl apply -f -
+```

--- a/api/manifests/base/arangodb-claim0-pvc.yaml
+++ b/api/manifests/base/arangodb-claim0-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: arangodb-claim0
+  name: arangodb-claim0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: standard
+status: {}

--- a/api/manifests/base/arangodb-deployment.yaml
+++ b/api/manifests/base/arangodb-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: arangodb
+  name: arangodb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: arangodb
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: arangodb
+        name: arangodb
+    spec:
+      containers:
+        - env:
+            - name: ARANGO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: ARANGO_ROOT_PASSWORD
+                  name: arango-secrets
+          image: arangodb:3.3.19
+          livenessProbe:
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            tcpSocket:
+              port: 8529
+          name: arangodb
+          ports:
+            - containerPort: 8529
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            tcpSocket:
+              port: 8529
+          resources: {}
+          volumeMounts:
+            - mountPath: /var/lib/arangodb3
+              name: arangodb-claim0
+      restartPolicy: Always
+      volumes:
+        - name: arangodb-claim0
+          persistentVolumeClaim:
+            claimName: arangodb-claim0
+status: {}

--- a/api/manifests/base/arangodb-service.yaml
+++ b/api/manifests/base/arangodb-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: arangodb
+spec:
+  ports:
+    - name: '8529'
+      port: 8529
+  selector:
+    app: arangodb
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/api/manifests/base/cybercrime-api-deployment.yaml
+++ b/api/manifests/base/cybercrime-api-deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cybercrime-api
+  name: cybercrime-api
+  namespace: default
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: cybercrime-api
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: cybercrime-api
+    spec:
+      initContainers:
+        - image: cdssnc/cybercrime-arangoinit
+          imagePullPolicy: Always
+          name: cybercrime-arangoinit
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: cybercrime-api
+                  key: DB_USER
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: cybercrime-api
+                  key: DB_NAME
+            - name: DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cybercrime-api
+                  key: DB_URL
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cybercrime-api
+                  key: DB_PASSWORD
+      containers:
+        - image: cdssnc/cybercrime-api
+          imagePullPolicy: Always
+          name: cybercrime-api
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: cybercrime-api
+                  key: DB_USER
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: cybercrime-api
+                  key: DB_NAME
+            - name: DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cybercrime-api
+                  key: DB_URL
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cybercrime-api
+                  key: DB_PASSWORD
+          resources: {}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/api/manifests/base/cybercrime-api-service.yaml
+++ b/api/manifests/base/cybercrime-api-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cybercrime-api
+spec:
+  ports:
+    - name: api-port
+      port: 3000
+      targetPort: 3000
+  selector:
+    app: cybercrime-api
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/api/manifests/base/kustomization.yaml
+++ b/api/manifests/base/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - cybercrime-api-deployment.yaml
+  - cybercrime-api-service.yaml
+  - arangodb-claim0-pvc.yaml
+  - arangodb-deployment.yaml
+  - arangodb-service.yaml

--- a/api/manifests/overlays/minikube/cybercrime-api-service.yaml
+++ b/api/manifests/overlays/minikube/cybercrime-api-service.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cybercrime-api
+spec:
+  type: NodePort

--- a/api/manifests/overlays/minikube/kustomization.yaml
+++ b/api/manifests/overlays/minikube/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - ../../base
+patches:
+  - cybercrime-api-service.yaml

--- a/frontend/manifests/base/kustomization.yaml
+++ b/frontend/manifests/base/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+  - datadog-agent.yaml
+  - datadog-serviceaccount.yaml
+  - todo-backend-crystal-deployment.yaml
+  - todo-backend-crystal-service.yaml
+  - todo-backend-python-deployment.yaml
+  - todo-backend-python-service.yaml
+  - todo-frontend-deployment.yaml
+  - todo-frontend-service.yaml
+  - traefik-ingress-controller-cluster-role-binding.yaml
+  - traefik-ingress-controller-cluster-role.yaml
+  - traefik-ingress-controller-deployment.yaml
+  - traefik-ingress-controller-service-account.yaml
+  - traefik-ingress-crystal.yaml
+  - traefik-ingress-python.yaml
+  - traefik-ingress.yaml

--- a/frontend/manifests/base/todo-frontend-deployment.yaml
+++ b/frontend/manifests/base/todo-frontend-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  generation: 1
+  labels:
+    app: todo-frontend
+  name: todo-frontend
+  namespace: default
+  annotations:
+    flux.weave.works/automated: 'true'
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 4
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: todo-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: todo-frontend
+    spec:
+      containers:
+        - image: cdssnc/todo-frontend
+          imagePullPolicy: Always
+          name: todo-frontend
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+  - datadog-agent.yaml
+  - datadog-serviceaccount.yaml
+  - todo-backend-crystal-deployment.yaml
+  - todo-backend-crystal-service.yaml
+  - todo-backend-python-deployment.yaml
+  - todo-backend-python-service.yaml
+  - todo-frontend-deployment.yaml
+  - todo-frontend-service.yaml
+  - traefik-ingress-controller-cluster-role-binding.yaml
+  - traefik-ingress-controller-cluster-role.yaml
+  - traefik-ingress-controller-deployment.yaml
+  - traefik-ingress-controller-service-account.yaml
+  - traefik-ingress-crystal.yaml
+  - traefik-ingress-python.yaml
+  - traefik-ingress.yaml


### PR DESCRIPTION
This config allows us to get the API running in Minikube with the following
steps:

```sh
minikube start --vm-driver=kvm2 --memory=8096
kubectl create secret generic arango-secrets --from-literal=ARANGO_ROOT_PASSWORD=soopersecret
kubectl create secret generic cybercrime-api --from-env-file=.env
kustomize build manifests/overlays/minikube/ | kubectl apply -f -
```