### PR TITLE
Refine ingress config

### DIFF
--- a/ingress/manifests/overlays/gke/traefik-ingress-controller-deployment.yaml
+++ b/ingress/manifests/overlays/gke/traefik-ingress-controller-deployment.yaml
@@ -13,7 +13,6 @@ spec:
     spec:
       containers:
         - args:
-            - --api
             - --kubernetes
             - --logLevel=DEBUG
             - --debug
@@ -38,9 +37,6 @@ spec:
             - containerPort: 443
               hostPort: 443
               name: https
-            - containerPort: 8080
-              hostPort: 8080
-              name: admin
           securityContext:
             capabilities:
               add:

--- a/ingress/manifests/overlays/gke/traefik-ingress-service.yaml
+++ b/ingress/manifests/overlays/gke/traefik-ingress-service.yaml
@@ -12,9 +12,6 @@ spec:
     - name: https
       port: 443
       protocol: TCP
-    - name: admin
-      port: 8080
-      protocol: TCP
   selector:
     k8s-app: traefik-ingress-lb
   type: LoadBalancer

--- a/ingress/manifests/overlays/minikube/kustomization.yaml
+++ b/ingress/manifests/overlays/minikube/kustomization.yaml
@@ -2,3 +2,5 @@ bases:
   - ../../base
 resources:
   - traefik-ingress-service.yaml
+patches:
+  - traefik-ingress-controller-deployment.yaml

--- a/ingress/manifests/overlays/minikube/traefik-ingress-controller-deployment.yaml
+++ b/ingress/manifests/overlays/minikube/traefik-ingress-controller-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     spec:
       containers:
         - args:
+            - --api
             - --kubernetes
             - --debug
             - --defaultentrypoints=http
@@ -23,6 +24,9 @@ spec:
             - containerPort: 80
               hostPort: 80
               name: http
+            - containerPort: 8080
+              hostPort: 8080
+              name: admin
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
This commit disables the traefik dashboard on GKE and enables it on Minikube
since it's useful for debugging.