### PR TITLE
Namespace api

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,16 +1,21 @@
-# RCMP prototype API
+# Report a cybercrime prototype API
 
-This is a simple hello world style API.
+This is the API for the report-a-cybercrime project. It's a
+[GraphQL](https://graphql.org) API backed by
+[ArangoDB](https://www.arangodb.com/).
 
 ### Running the API
 
 The API requires a few environmental variables to run. These are expected to be
 in a `.env` file, which you should create based on `.env.example`.
 
-With those in place and [ArangoDB](https://www.arangodb.com/) running, you can
+With those in place and ArangoDB running, you can
 start the API in the standard way.
 
 ```sh
+# install the dependencies
+npm install
+# start the api
 npm start
 ```
 
@@ -35,10 +40,12 @@ the following.
 ```sh
 # start minikube with a non-resource hogging driver and lots of memory
 minikube start --vm-driver=kvm2 --memory=8096
+# create the cybercrime-api namespace to scope access to the secrets
+kubectl create namespace cybercrime-api
 # create a secret for the root db password
-kubectl create secret generic arango-secrets --from-literal=ARANGO_ROOT_PASSWORD=soopersecret
+kubectl create secret generic arango-secrets --namespace=cybercrime-api --from-literal=ARANGO_ROOT_PASSWORD=soopersecret
 # create a secret from the env file
-kubectl create secret generic cybercrime-api --from-env-file=.env
+kubectl create secret generic cybercrime-api --namespace=cybercrime-api --from-env-file=.env
 # generate the config and pipe it into kubectl
 kustomize build manifests/overlays/minikube/ | kubectl apply -f -
 ```

--- a/api/manifests/base/arangodb-claim0-pvc.yaml
+++ b/api/manifests/base/arangodb-claim0-pvc.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     io.kompose.service: arangodb-claim0
   name: arangodb-claim0
+  namespace: cybercrime-api
 spec:
   accessModes:
     - ReadWriteOnce

--- a/api/manifests/base/arangodb-deployment.yaml
+++ b/api/manifests/base/arangodb-deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  namespace: cybercrime-api
   creationTimestamp: null
   labels:
     app: arangodb

--- a/api/manifests/base/arangodb-deployment.yaml
+++ b/api/manifests/base/arangodb-deployment.yaml
@@ -42,10 +42,10 @@ spec:
           resources: {}
           volumeMounts:
             - mountPath: /var/lib/arangodb3
-              name: arangodb-claim0
+              name: arangodb-claim
       restartPolicy: Always
       volumes:
-        - name: arangodb-claim0
+        - name: arangodb-claim
           persistentVolumeClaim:
-            claimName: arangodb-claim0
+            claimName: arangodb-claim
 status: {}

--- a/api/manifests/base/arangodb-service.yaml
+++ b/api/manifests/base/arangodb-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: cybercrime-api
   name: arangodb
 spec:
   ports:

--- a/api/manifests/base/cybercrime-api-deployment.yaml
+++ b/api/manifests/base/cybercrime-api-deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: cybercrime-api
   labels:
     app: cybercrime-api
   name: cybercrime-api
-  namespace: default
 spec:
   replicas: 1
   revisionHistoryLimit: 10

--- a/api/manifests/base/cybercrime-api-ingress.yaml
+++ b/api/manifests/base/cybercrime-api-ingress.yaml
@@ -1,6 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+  namespace: cybercrime-api
   annotations:
     kubernetes.io/ingress.class: traefik
   name: cybercrime-api-ingress

--- a/api/manifests/base/cybercrime-api-namespace.yaml
+++ b/api/manifests/base/cybercrime-api-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: cybercrime-api
+spec: {}
+status: {}

--- a/api/manifests/base/cybercrime-api-service.yaml
+++ b/api/manifests/base/cybercrime-api-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: cybercrime-api
   name: cybercrime-api
 spec:
   ports:

--- a/api/manifests/base/kustomization.yaml
+++ b/api/manifests/base/kustomization.yaml
@@ -1,5 +1,4 @@
 resources:
-  - arangodb-claim0-pvc.yaml
   - arangodb-deployment.yaml
   - arangodb-service.yaml
   - cybercrime-api-deployment.yaml

--- a/api/manifests/base/kustomization.yaml
+++ b/api/manifests/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - cybercrime-api-deployment.yaml
   - cybercrime-api-ingress.yaml
   - cybercrime-api-service.yaml
+  - cybercrime-api-namespace.yaml

--- a/api/manifests/overlays/gke/arango-claim.yaml
+++ b/api/manifests/overlays/gke/arango-claim.yaml
@@ -1,15 +1,12 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  labels:
-    io.kompose.service: arangodb-claim0
-  name: arangodb-claim0
+  name: arangodb-claim
   namespace: cybercrime-api
 spec:
+  storageClassName: ssd
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
-  storageClassName: standard
-status: {}
+      storage: 100Gi

--- a/api/manifests/overlays/gke/cybercrime-api-service.yaml
+++ b/api/manifests/overlays/gke/cybercrime-api-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: cybercrime-api
   name: cybercrime-api
 spec:
-  type: LoadBalancer
+  type: ClusterIP

--- a/api/manifests/overlays/gke/kustomization.yaml
+++ b/api/manifests/overlays/gke/kustomization.yaml
@@ -2,3 +2,6 @@ bases:
   - ../../base
 patches:
   - cybercrime-api-service.yaml
+resources:
+  - arango-claim.yaml
+  - ssd-storageclass.yaml

--- a/api/manifests/overlays/gke/ssd-storageclass.yaml
+++ b/api/manifests/overlays/gke/ssd-storageclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ssd
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd

--- a/api/manifests/overlays/minikube/arango-claim.yaml
+++ b/api/manifests/overlays/minikube/arango-claim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: arangodb-claim
+  namespace: cybercrime-api
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: standard
+status: {}

--- a/api/manifests/overlays/minikube/cybercrime-api-service.yaml
+++ b/api/manifests/overlays/minikube/cybercrime-api-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: cybercrime-api
   name: cybercrime-api
 spec:
   type: NodePort

--- a/api/manifests/overlays/minikube/kustomization.yaml
+++ b/api/manifests/overlays/minikube/kustomization.yaml
@@ -2,3 +2,5 @@ bases:
   - ../../base
 patches:
   - cybercrime-api-service.yaml
+resources:
+  - arango-claim.yaml


### PR DESCRIPTION
Moving the API and db into the cybercrime-api namespace, and fixing the storage so that Arango is using ssd. Updated the readme with relevant instructions.