### PR TITLE
Add stats field to query schema

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -36,6 +36,7 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "verbose": true
+    "verbose": true,
+    "setupTestFrameworkScriptFile": "<rootDir>/setUpJest.js"
   }
 }

--- a/api/setUpJest.js
+++ b/api/setUpJest.js
@@ -1,0 +1,1 @@
+require('dotenv-safe').config()

--- a/api/src/Stats.js
+++ b/api/src/Stats.js
@@ -1,0 +1,16 @@
+const { GraphQLObjectType, GraphQLInt } = require('graphql')
+
+const Stats = new GraphQLObjectType({
+  name: 'Stats',
+  fields: () => ({
+    reportCount: {
+      type: GraphQLInt,
+      description: 'The total number of reports submitted.',
+      resolve: (_root, _args, { db }, _info) => {
+        return db.countReports()
+      },
+    },
+  }),
+})
+
+module.exports.Stats = Stats

--- a/api/src/__tests__/database.test.js
+++ b/api/src/__tests__/database.test.js
@@ -1,0 +1,54 @@
+const { dbinit } = require('../dbinit')
+const { makeTestDatabase, dbNameFromFile } = require('../utils')
+
+const { DB_USER: user, DB_URL: url, DB_PASSWORD: password } = process.env
+
+let db, drop, reports
+
+describe('dbinit', () => {
+  describe('produces database functions given a database object', () => {
+    beforeAll(async () => {
+      ;({ db, drop } = await makeTestDatabase({
+        dbname: dbNameFromFile(__filename),
+        user,
+        password,
+        url,
+        collections: ['reports'],
+      }))
+
+      reports = db.collection('reports')
+    })
+
+    afterAll(async () => {
+      await drop()
+    })
+
+    afterEach(async () => {
+      await reports.truncate()
+    })
+
+    describe('countReports', () => {
+      it('lets you query the number of reports via a stats type', async () => {
+        await reports.save({ foo: 'I am a fake report' })
+        let dbfunctions = await dbinit(db)
+
+        let count = await dbfunctions.countReports()
+
+        expect(count).toEqual(1)
+      })
+    })
+
+    describe('saveReport', () => {
+      it('saves a report to the reports collection', async () => {
+        let dbfunctions = await dbinit(db)
+
+        let _savedReport = await dbfunctions.saveReport({
+          foo: 'I am a fake report',
+        })
+
+        let { count } = await reports.count()
+        expect(count).toEqual(1)
+      })
+    })
+  })
+})

--- a/api/src/__tests__/schema.test.js
+++ b/api/src/__tests__/schema.test.js
@@ -1,11 +1,8 @@
 const { schema } = require('../schema')
 
-describe('GraphQL Schema', () => {
-  it('Has a hello field whose name is hello', () => {
+describe('GraphQL Query Schema', () => {
+  it('Has a stats field', () => {
     let Query = schema.getType('Query')
-    let {
-      hello: { name },
-    } = Query.getFields()
-    expect(name).toEqual('hello')
+    expect(Query.getFields()).toHaveProperty('stats')
   })
 })

--- a/api/src/dbinit.js
+++ b/api/src/dbinit.js
@@ -2,18 +2,18 @@ const { aql } = require('arangojs')
 
 const dbinit = async db => {
   return {
-    hello: async () => {
-      let query = aql`
-          RETURN "Hello world"
-      `
-      let results = await db.query(query)
-      return results.next()
-    },
     saveReport: async report => {
       let query = aql`
         INSERT ${report} IN reports
         RETURN NEW
   `
+      let results = await db.query(query)
+      return results.next()
+    },
+    countReports: async () => {
+      let query = aql`
+        RETURN COUNT(reports)
+      `
       let results = await db.query(query)
       return results.next()
     },

--- a/api/src/schema.js
+++ b/api/src/schema.js
@@ -1,4 +1,5 @@
 const { GraphQLSchema, GraphQLObjectType, GraphQLString } = require('graphql')
+const { Stats } = require('./Stats')
 
 var Report = new GraphQLObjectType({
   name: 'Report',
@@ -18,12 +19,10 @@ var Report = new GraphQLObjectType({
 const query = new GraphQLObjectType({
   name: 'Query',
   fields: () => ({
-    hello: {
-      description: 'greets the world',
-      type: GraphQLString,
-      resolve: (_root, _args, { db }, _info) => {
-        return db.hello()
-      },
+    stats: {
+      description: 'Stats about report collection',
+      type: Stats,
+      resolve: () => ({}),
     },
   }),
 })


### PR DESCRIPTION
This commit adds a stats field to the query schema allowing users to as for the
total number of reports with a query like this:

```graphql
{
  stats {
    reportCount
  }
}
```