### PR TITLE
Use docker-compose for local dev

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ trim_trailing_whitespace = false
 
 [COMMIT_EDITMSG]
 max_line_length = 0
+
+[Makefile]
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-iHELL ?= /usr/bin/bash
+SHELL ?= /usr/bin/bash
 # set up minikube for local testing.
 setup:
 	docker-compose build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+iHELL ?= /usr/bin/bash
+# set up minikube for local testing.
+setup:
+	docker-compose build
+dev:
+	docker-compose up
+.ONESHELL:

--- a/api/index.js
+++ b/api/index.js
@@ -1,11 +1,12 @@
 const { Server } = require('./src/server')
 const { db } = require('./src/db')
 
+const port = process.env.PORT || 3000
 Server(db)
   .then(server => {
-    server.listen({ port: 3000 }, () =>
+    server.listen({ port }, () =>
       // eslint-disable-next-line no-console
-      console.log(`🚀 API listening on port 3000`),
+      console.log(`🚀 API listening on port ${port}`),
     )
   })
   .catch(console.log)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+version: "3.7"
+
+services:
+  arangodb:
+    image: arangodb/arangodb:3.1.19
+    environment:
+      - ARANGO_ROOT_PASSWORD=$DB_PASSWORD
+    ports:
+      - "8529"
+    labels:
+      - "traefik.backend=arangodb"
+      - "traefik.frontend.rule=PathPrefix:/"
+      - "traefik.frontend.entryPoints=arango"
+      - "traefik.port=8529"
+    volumes:
+      - arangodata:/var/lib/arangodb3
+  api:
+    environment:
+      - PORT=3002
+      - DB_NAME=cybercrime
+      - DB_URL=http://arangodb:8529
+      - DB_USER
+      - DB_PASSWORD
+    build:
+      context: ./api
+      dockerfile: Dockerfile
+    ports:
+      - "3002"
+    volumes:
+      - ./api:/app
+    command: npm start
+    labels:
+      - "traefik.backend=api"
+      - "traefik.frontend.rule=PathPrefix:/graphql"
+      - "traefik.frontend.entryPoints=http"
+      - "traefik.port=3002"
+  traefik:
+    image: traefik:1.7
+    command: --docker --api --entrypoints="Name:http Address::3000" --entrypoints="Name:arango Address::8529" --defaultentrypoints="Name:http,arango"
+    ports:
+      - "3000:3000"
+      - "8529:8529"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  frontend:
+    environment:
+      - RAZZLE_PORT=3000
+    ports:
+      - "3000"
+      - "3001:3001"
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    labels:
+      - "traefik.backend=frontend"
+      - "traefik.frontend.rule=PathPrefix:/"
+      - "traefik.frontend.entryPoints=http"
+      - "traefik.port=3000"
+    volumes:
+      - ./frontend:/app
+    command: npm run dev
+volumes:
+  arangodata:


### PR DESCRIPTION
This commit adds a docker-compose file to bring up a working development environment.
I've added a make file to simplify things a little further, which leaves us with two simple commands to get things going:

```sh
make setup
DB_USER=root DB_PASSWORD=test make dev
```

This will bring up the frontend listening on localhost:3000, the API, at
localhost:3000/graphql and ArangoDB, with it's admin interface on
localhost:8529.

The first time you run this you will need to log into arangodb and create a database (called cybercrime) and a collection (called reports).