### PR TITLE
Add repository field to package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "report-a-cybercrime",
   "version": "0.0.1",
   "license": "MIT",
+  "repository": "github:cds-snc/report-a-cybercrime",
   "scripts": {
     "dev": "razzle start",
     "build": "razzle build",


### PR DESCRIPTION
This field was missing which caused the warning:
```sh
npm WARN report-a-cybercrime@0.0.1 No repository field.
```
This simply adds the missing field which resolves the problem.