### PR TITLE
Add repository field to package.json

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,6 +13,7 @@
   },
   "author": "CDS",
   "license": "MIT",
+  "repository": "github:cds-snc/report-a-cybercrime",
   "dependencies": {
     "arangojs": "^6.9.0",
     "cors": "^2.8.5",


### PR DESCRIPTION
This silences a warning displayed during installs.