### PR TITLE
Change LanguageSwitcher to a button

### DIFF
--- a/frontend/src/LanguageSwitcher.js
+++ b/frontend/src/LanguageSwitcher.js
@@ -1,33 +1,41 @@
 import React from 'react'
 import { Query, Mutation } from 'react-apollo'
-import styled, { css } from 'react-emotion'
+import { css } from 'react-emotion'
 import {
   GET_LANGUAGE_QUERY,
   CHANGE_LANGUAGE_MUTATION,
 } from './utils/queriesAndMutations'
 
-const A = styled('a')`
+const buttonThatLooksLikeALink = css`
+  background: none;
+  border: none;
   font-family: Arial, Helvetica, sans-serif;
   color: white;
   text-decoration: underline;
   &:hover {
     cursor: pointer;
   }
+  &:focus {
+    outline: 3px solid #ffbf47;
+  }
 `
-const thing = css`
+const languageSwitcher = css`
   align-content: right;
   display: block-inline;
 `
 
 export const LanguageSwitcher = () => (
-  <section className={thing}>
+  <section className={languageSwitcher}>
     <Query query={GET_LANGUAGE_QUERY}>
       {({ data: { language } }) => (
         <Mutation mutation={CHANGE_LANGUAGE_MUTATION}>
           {switchLanguage => (
-            <A onClick={() => switchLanguage()}>
+            <button
+              className={buttonThatLooksLikeALink}
+              onClick={() => switchLanguage()}
+            >
               {language === 'en' ? 'Français' : 'English'}
-            </A>
+            </button>
           )}
         </Mutation>
       )}

--- a/frontend/src/LanguageSwitcher.js
+++ b/frontend/src/LanguageSwitcher.js
@@ -9,7 +9,7 @@ import {
 const buttonThatLooksLikeALink = css`
   background: none;
   border: none;
-  font-family: Arial, Helvetica, sans-serif;
+  font: inherit;
   color: white;
   text-decoration: underline;
   &:hover {

--- a/frontend/src/__tests__/LanguageSwitcher.test.js
+++ b/frontend/src/__tests__/LanguageSwitcher.test.js
@@ -27,4 +27,13 @@ describe('<LanguageSwitcher />', () => {
       expect(wrapper.text()).toMatch(/English/)
     })
   })
+
+  it(`renders a button and not a link because it doesn't navigate anywhere`, () => {
+    const wrapper = mount(
+      <ApolloProvider client={testClient({ language: 'fr' })}>
+        <LanguageSwitcher />
+      </ApolloProvider>,
+    )
+    expect(wrapper.find('button')).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
This commit changes the LanguageSwitcher component to output a button. The
previous "a" element had no href attribute (since it wasn't navigating
anywhere) and was therefore not included in the accessibility tree. Switching
to a button fixes this and closes #63