### PR TITLE
Improve TLS settings

### DIFF
--- a/ingress/manifests/traefik-ingress-controller-deployment.yaml
+++ b/ingress/manifests/traefik-ingress-controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - --debug
             - --defaultentrypoints=http,https
             - --entrypoints=Name:http Address::80 Redirect.EntryPoint:https Compress:true
-            - --entrypoints=Name:https Address::443 TLS Compress:true
+            - --entrypoints=Name:https Address::443 TLS Compress:true TLS.MinVersion:VersionTLS12 TLS.CipherSuites:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 TLS.SniStrict:true
             - --acme
             - --acme.onhostrule
             - --acme.entrypoint=https


### PR DESCRIPTION
This commit sets the TLS minimum version to 1.2 and specifies the ciphers
available. The ciphers available are the ones defined in Go's tls library:
 https://golang.org/src/crypto/tls/cipher_suites.go

The current configuration gets and A+ from SSLLabs.