### PR TITLE
Tweak PWA

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,4 +1,4 @@
-const filesToCache = ['/', '/static/js/bundle.js']
+const filesToCache = ['/']
 
 const staticCacheName = 'pages-cache-v1'
 
@@ -32,8 +32,15 @@ self.addEventListener('activate', event => {
 self.addEventListener('fetch', function(event) {
   console.log('Fetch', event.request)
   event.respondWith(
-    fetch(event.request).catch(function() {
-      return caches.match(event.request)
-    }),
+    fetch(event.request)
+      .then(response => {
+        return caches.open(staticCacheName).then(cache => {
+          cache.put(event.request, response.clone())
+          return response
+        })
+      })
+      .catch(function() {
+        return caches.match(event.request)
+      }),
   )
 })

--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,4 +1,4 @@
-const filesToCache = ['/']
+let filesToCache = ['/']
 
 const staticCacheName = 'pages-cache-v1'
 
@@ -7,7 +7,17 @@ self.addEventListener('install', event => {
   self.skipWaiting()
   event.waitUntil(
     caches.open(staticCacheName).then(cache => {
-      return cache.addAll(filesToCache)
+      return fetch('assets')
+        .then(response => {
+          return response.json()
+        })
+        .then(assets => {
+          filesToCache.push(assets.client.js)
+          return filesToCache
+        })
+        .then(files => {
+          return cache.addAll(files)
+        })
     }),
   )
 })

--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,4 +1,4 @@
-const filesToCache = ['/']
+const filesToCache = ['/', '/static/js/bundle.js']
 
 const staticCacheName = 'pages-cache-v1'
 
@@ -30,6 +30,7 @@ self.addEventListener('activate', event => {
 
 // Network falling back to the cache
 self.addEventListener('fetch', function(event) {
+  console.log('Fetch', event.request)
   event.respondWith(
     fetch(event.request).catch(function() {
       return caches.match(event.request)

--- a/frontend/src/server.js
+++ b/frontend/src/server.js
@@ -28,6 +28,9 @@ server
       languages: ['en', 'fr'],
     }),
   )
+  .get('/assets', (req, res) => {
+    res.status(200).send(JSON.stringify(assets))
+  })
   .get('/monitoring/alive', (req, res) => {
     res.status(200).send('yes')
   })


### PR DESCRIPTION
Problem: the bundle file has a random hash in it due to Razzle, so the precaching on install fails.

In this PR the service worker  fetches Razzle’s asset file and uses that to get the file name of the bundle. 