### PR TITLE
Use minimal style for lingui json files

### DIFF
--- a/frontend/.linguirc
+++ b/frontend/.linguirc
@@ -1,5 +1,0 @@
-{
-   "localeDir": "src/locales/",
-   "srcPathDirs": ["src/"],
-   "format": "po"
-}

--- a/frontend/locale/en/messages.json
+++ b/frontend/locale/en/messages.json
@@ -1,170 +1,39 @@
 {
-  "Bank accounts": {
-    "translation": "Bank accounts",
-    "origin": [["src/Screen2.js", 122]]
-  },
-  "Describe what happened": {
-    "translation": "Describe what happened",
-    "origin": [["src/Screen1.js", 41]]
-  },
-  "Describe what happened.": {
-    "translation": "Describe what happened.",
-    "origin": [["src/LandingPage.js", 45]]
-  },
-  "Did you lose money or personal information?": {
-    "translation": "Did you lose money or personal information?",
-    "origin": [["src/Screen3.js", 130]]
-  },
-  "Email address": {
-    "translation": "Email address",
-    "origin": [["src/Screen2.js", 118]]
-  },
-  "For more information on how to stay safe online, you can visit <0>GetCyberSafe</0> and the <1>Top 10 Cyber Crime Prevention Tips.</1>": {
-    "translation": "For more information on how to stay safe online, you can visit <0>GetCyberSafe</0> and the <1>Top 10 Cyber Crime Prevention Tips.</1>",
-    "origin": [["src/Thanks.js", 49]]
-  },
-  "For research purposes only.": {
-    "translation": "For research purposes only.",
-    "origin": [["src/Home.js", 23]]
-  },
-  "Have you or someone you know encountered a cybercrime?": {
-    "translation": "Have you or someone you know encountered a cybercrime?",
-    "origin": [["src/LandingPage.js", 38]]
-  },
-  "How did that happen?": {
-    "translation": "How did that happen?",
-    "origin": [["src/Screen2.js", 137]]
-  },
-  "How were you affected?": {
-    "translation": "How were you affected?",
-    "origin": [["src/Screen1.js", 52], ["src/Screen3.js", 122]]
-  },
-  "In general terms, who was involved?": {
-    "translation": "In general terms, who was involved?",
-    "origin": [["src/Screen1.js", 49]]
-  },
-  "I’m not sure": {
-    "translation": "I’m not sure",
-    "origin": [["src/Screen2.js", 123]]
-  },
-  "Landing Page": {
-    "translation": "Landing Page",
-    "origin": [
-      ["src/Screen1.js", 36],
-      ["src/Screen2.js", 130],
-      ["src/Screen3.js", 112]
-    ]
-  },
-  "Next": {
-    "translation": "Next",
-    "origin": [
-      ["src/Screen2.js", 107],
-      ["src/Screen3.js", 97],
-      ["src/WhatHappenedForm.js", 62]
-    ]
-  },
-  "Other": {
-    "translation": "Other",
-    "origin": [["src/Screen2.js", 90]]
-  },
-  "Phone": {
-    "translation": "Phone",
-    "origin": [["src/Screen2.js", 119]]
-  },
-  "Please complete the form to tell us what was affected.": {
-    "translation": "Please complete the form to tell us what was affected.",
-    "origin": [["src/Screen2.js", 52]]
-  },
-  "Please complete the text box to tell us how you were affected.": {
-    "translation": "Please complete the text box to tell us how you were affected.",
-    "origin": [["src/Screen3.js", 61]]
-  },
-  "Please complete the text box to tell us what happened.": {
-    "translation": "Please complete the text box to tell us what happened.",
-    "origin": [["src/WhatHappenedForm.js", 27]]
-  },
-  "Please do not provide any personal information.": {
-    "translation": "Please do not provide any personal information.",
-    "origin": [["src/LandingPage.js", 54], ["src/Screen1.js", 56]]
-  },
-  "Privacy": {
-    "translation": "Privacy",
-    "origin": [["src/App.js", 99]]
-  },
-  "Select where you encountered the cybercrime.": {
-    "translation": "Select where you encountered the cybercrime.",
-    "origin": [["src/LandingPage.js", 48]]
-  },
-  "Share how you were impacted.": {
-    "translation": "Share how you were impacted.",
-    "origin": [["src/LandingPage.js", 51]]
-  },
-  "Share your story→": {
-    "translation": "Share your story→",
-    "origin": [["src/LandingPage.js", 57]]
-  },
-  "Social media accounts": {
-    "translation": "Social media accounts",
-    "origin": [["src/Screen2.js", 121]]
-  },
-  "Tell us your story in three easy steps:": {
-    "translation": "Tell us your story in three easy steps:",
-    "origin": [["src/LandingPage.js", 41]]
-  },
-  "Terms and Conditions": {
-    "translation": "Terms and Conditions",
-    "origin": [["src/App.js", 110]]
-  },
-  "Text messages": {
-    "translation": "Text messages",
-    "origin": [["src/Screen2.js", 120]]
-  },
-  "Thank you for sharing your story.": {
-    "translation": "Thank you for sharing your story.",
-    "origin": [["src/Thanks.js", 42]]
-  },
-  "Was your reputation or productivity affected?": {
-    "translation": "Was your reputation or productivity affected?",
-    "origin": [["src/Screen3.js", 133]]
-  },
-  "Website": {
-    "translation": "Website",
-    "origin": [["src/Screen2.js", 117]]
-  },
-  "What Happened": {
-    "translation": "What Happened",
-    "origin": [["src/WhatHappenedForm.js", 42]]
-  },
-  "What happened?": {
-    "translation": "What happened?",
-    "origin": [["src/Screen2.js", 133], ["src/Screen3.js", 115]]
-  },
-  "What is a cybercrime?": {
-    "translation": "What is a cybercrime?",
-    "origin": [["src/LandingPage.js", 67]]
-  },
-  "What was affected? Choose all that apply.": {
-    "translation": "What was affected? Choose all that apply.",
-    "origin": [["src/Screen2.js", 69]]
-  },
-  "What was involved?": {
-    "translation": "What was involved?",
-    "origin": [["src/Screen3.js", 118]]
-  },
-  "What was your reaction?": {
-    "translation": "What was your reaction?",
-    "origin": [["src/Screen3.js", 127]]
-  },
-  "When did it take place?": {
-    "translation": "When did it take place?",
-    "origin": [["src/Screen1.js", 46]]
-  },
-  "You are the {0}th person to use this tool to share a cybercrime story.": {
-    "translation": "You are the {0}th person to use this tool to share a cybercrime story.",
-    "origin": [["src/Stats.js", 16]]
-  },
-  "loading...": {
-    "translation": "loading...",
-    "origin": [["src/withLanguageSwitching.js", 23]]
-  }
+  "Bank accounts": "Bank accounts",
+  "Describe what happened": "Describe what happened",
+  "Describe what happened.": "Describe what happened.",
+  "Did you lose money or personal information?": "Did you lose money or personal information?",
+  "Email address": "Email address",
+  "For more information on how to stay safe online, you can visit <0>GetCyberSafe</0> and the <1>Top 10 Cyber Crime Prevention Tips.</1>": "For more information on how to stay safe online, you can visit <0>GetCyberSafe</0> and the <1>Top 10 Cyber Crime Prevention Tips.</1>",
+  "For research purposes only.": "For research purposes only.",
+  "Have you or someone you know encountered a cybercrime?": "Have you or someone you know encountered a cybercrime?",
+  "How did that happen?": "How did that happen?",
+  "How were you affected?": "How were you affected?",
+  "In general terms, who was involved?": "In general terms, who was involved?",
+  "I’m not sure": "I’m not sure",
+  "Next": "Next",
+  "Other": "Other",
+  "Phone": "Phone",
+  "Please complete the form to tell us what was affected.": "Please complete the form to tell us what was affected.",
+  "Please complete the text box to tell us how you were affected.": "Please complete the text box to tell us how you were affected.",
+  "Please complete the text box to tell us what happened.": "Please complete the text box to tell us what happened.",
+  "Please do not provide any personal information.": "Please do not provide any personal information.",
+  "Privacy": "Privacy",
+  "Select where you encountered the cybercrime.": "Select where you encountered the cybercrime.",
+  "Share how you were impacted.": "Share how you were impacted.",
+  "Share your story→": "Share your story→",
+  "Social media accounts": "Social media accounts",
+  "Tell us your story in three easy steps:": "Tell us your story in three easy steps:",
+  "Terms and Conditions": "Terms and Conditions",
+  "Text messages": "Text messages",
+  "Thank you for sharing your story.": "Thank you for sharing your story.",
+  "Was your reputation or productivity affected?": "Was your reputation or productivity affected?",
+  "Website": "Website",
+  "What Happened": "What Happened",
+  "What is a cybercrime?": "What is a cybercrime?",
+  "What was affected? Choose all that apply.": "What was affected? Choose all that apply.",
+  "What was your reaction?": "What was your reaction?",
+  "When did it take place?": "When did it take place?",
+  "You are the {0}th person to use this tool to share a cybercrime story.": "You are the {0}th person to use this tool to share a cybercrime story.",
+  "loading...": "loading..."
 }

--- a/frontend/locale/fr/messages.json
+++ b/frontend/locale/fr/messages.json
@@ -1,170 +1,39 @@
 {
-  "Bank accounts": {
-    "translation": "Comptes bancaires",
-    "origin": [["src/Screen2.js", 122]]
-  },
-  "Describe what happened": {
-    "translation": "Décrivez ce qui s'est passé",
-    "origin": [["src/Screen1.js", 41]]
-  },
-  "Describe what happened.": {
-    "translation": "Décrivez ce qui s'est passé.",
-    "origin": [["src/LandingPage.js", 45]]
-  },
-  "Did you lose money or personal information?": {
-    "translation": "Avez-vous perdu de l'argent ou des renseignements personnels?",
-    "origin": [["src/Screen3.js", 130]]
-  },
-  "Email address": {
-    "translation": "Adresse de courriel",
-    "origin": [["src/Screen2.js", 118]]
-  },
-  "For more information on how to stay safe online, you can visit <0>GetCyberSafe</0> and the <1>Top 10 Cyber Crime Prevention Tips.</1>": {
-    "translation": "Pour plus d'informations sur la façon de rester en sécurité en ligne, vous pouvez visiter <0>Pensez cybersécurité</0> et le <1>Les dix meilleurs conseils pour prévenir un cybercrime.</1>",
-    "origin": [["src/Thanks.js", 49]]
-  },
-  "For research purposes only.": {
-    "translation": "À des fins de recherche seulement.",
-    "origin": [["src/Home.js", 23]]
-  },
-  "Have you or someone you know encountered a cybercrime?": {
-    "translation": "Avez-vous, ou connaissez-vous quelqu'un qui a, été confronté à un cybercrime?",
-    "origin": [["src/LandingPage.js", 38]]
-  },
-  "How did that happen?": {
-    "translation": "Comment cela s'est-il passé?",
-    "origin": [["src/Screen2.js", 137]]
-  },
-  "How were you affected?": {
-    "translation": "Comment avez-vous été affecté?",
-    "origin": [["src/Screen1.js", 52], ["src/Screen3.js", 122]]
-  },
-  "In general terms, who was involved?": {
-    "translation": "En termes généraux, qui était impliqué?",
-    "origin": [["src/Screen1.js", 49]]
-  },
-  "I’m not sure": {
-    "translation": "Je ne suis pas certain(e)",
-    "origin": [["src/Screen2.js", 123]]
-  },
-  "Landing Page": {
-    "translation": "Page d'atterrissage",
-    "origin": [
-      ["src/Screen1.js", 36],
-      ["src/Screen2.js", 130],
-      ["src/Screen3.js", 112]
-    ]
-  },
-  "Next": {
-    "translation": "Suivant",
-    "origin": [
-      ["src/Screen2.js", 107],
-      ["src/Screen3.js", 97],
-      ["src/WhatHappenedForm.js", 62]
-    ]
-  },
-  "Other": {
-    "translation": "Autre",
-    "origin": [["src/Screen2.js", 90]]
-  },
-  "Phone": {
-    "translation": "Téléphone",
-    "origin": [["src/Screen2.js", 119]]
-  },
-  "Please complete the form to tell us what was affected.": {
-    "translation": "Veuillez remplir le formulaire pour nous dire ce qui a été touché.",
-    "origin": [["src/Screen2.js", 52]]
-  },
-  "Please complete the text box to tell us how you were affected.": {
-    "translation": "Veuillez remplir la zone de texte pour nous dire comment vous avez été touché.",
-    "origin": [["src/Screen3.js", 61]]
-  },
-  "Please complete the text box to tell us what happened.": {
-    "translation": "Veuillez remplir la zone de texte pour nous dire ce qui s'est passé.",
-    "origin": [["src/WhatHappenedForm.js", 27]]
-  },
-  "Please do not provide any personal information.": {
-    "translation": "Veuillez ne pas fournir de renseignements personnels.",
-    "origin": [["src/LandingPage.js", 54], ["src/Screen1.js", 56]]
-  },
-  "Privacy": {
-    "translation": "Confidentialité",
-    "origin": [["src/App.js", 99]]
-  },
-  "Select where you encountered the cybercrime.": {
-    "translation": "Veuillez sélectionner où vous avez rencontré la cybercriminalité.",
-    "origin": [["src/LandingPage.js", 48]]
-  },
-  "Share how you were impacted.": {
-    "translation": "Partagez comment vous avez été affecté.",
-    "origin": [["src/LandingPage.js", 51]]
-  },
-  "Share your story→": {
-    "translation": "Partagez votre histoire→",
-    "origin": [["src/LandingPage.js", 57]]
-  },
-  "Social media accounts": {
-    "translation": "Comptes de médias sociaux",
-    "origin": [["src/Screen2.js", 121]]
-  },
-  "Tell us your story in three easy steps:": {
-    "translation": "Racontez-nous votre histoire en trois étapes faciles:",
-    "origin": [["src/LandingPage.js", 41]]
-  },
-  "Terms and Conditions": {
-    "translation": "Avis",
-    "origin": [["src/App.js", 110]]
-  },
-  "Text messages": {
-    "translation": "Messages texte",
-    "origin": [["src/Screen2.js", 120]]
-  },
-  "Thank you for sharing your story.": {
-    "translation": "Merci d'avoir partagé votre histoire.",
-    "origin": [["src/Thanks.js", 42]]
-  },
-  "Was your reputation or productivity affected?": {
-    "translation": "Votre réputation ou votre productivité ont-elles été affectées?",
-    "origin": [["src/Screen3.js", 133]]
-  },
-  "Website": {
-    "translation": "Site web",
-    "origin": [["src/Screen2.js", 117]]
-  },
-  "What Happened": {
-    "translation": "Qu'est-ce qui s'est passé?",
-    "origin": [["src/WhatHappenedForm.js", 42]]
-  },
-  "What happened?": {
-    "translation": "Qu'est-ce qui s'est passé?",
-    "origin": [["src/Screen2.js", 133], ["src/Screen3.js", 115]]
-  },
-  "What is a cybercrime?": {
-    "translation": "Qu'est-ce qu'un cybercrime?",
-    "origin": [["src/LandingPage.js", 67]]
-  },
-  "What was affected? Choose all that apply.": {
-    "translation": "Qu'est-ce qui a été affecté? Cochez toutes les réponses qui s'appliquent.",
-    "origin": [["src/Screen2.js", 69]]
-  },
-  "What was involved?": {
-    "translation": "Qu'est-ce qui a été impliqué?",
-    "origin": [["src/Screen3.js", 118]]
-  },
-  "What was your reaction?": {
-    "translation": "Quelle a été votre réaction?",
-    "origin": [["src/Screen3.js", 127]]
-  },
-  "When did it take place?": {
-    "translation": "Quand cela s'est-il passé?",
-    "origin": [["src/Screen1.js", 46]]
-  },
-  "You are the {0}th person to use this tool to share a cybercrime story.": {
-    "translation": "Vous êtes la {0}e personne à utiliser cet outil pour partager une histoire de cybercriminalité.",
-    "origin": [["src/Stats.js", 16]]
-  },
-  "loading...": {
-    "translation": "chargement en cours...",
-    "origin": [["src/withLanguageSwitching.js", 23]]
-  }
+  "Bank accounts": "Comptes bancaires",
+  "Describe what happened": "Décrivez ce qui s'est passé",
+  "Describe what happened.": "Décrivez ce qui s'est passé.",
+  "Did you lose money or personal information?": "Avez-vous perdu de l'argent ou des renseignements personnels?",
+  "Email address": "Adresse de courriel",
+  "For more information on how to stay safe online, you can visit <0>GetCyberSafe</0> and the <1>Top 10 Cyber Crime Prevention Tips.</1>": "Pour plus d'informations sur la façon de rester en sécurité en ligne, vous pouvez visiter <0>Pensez cybersécurité</0> et le <1>Les dix meilleurs conseils pour prévenir un cybercrime.</1>",
+  "For research purposes only.": "À des fins de recherche seulement.",
+  "Have you or someone you know encountered a cybercrime?": "Avez-vous, ou connaissez-vous quelqu'un qui a, été confronté à un cybercrime?",
+  "How did that happen?": "Comment cela s'est-il passé?",
+  "How were you affected?": "Comment avez-vous été affecté?",
+  "In general terms, who was involved?": "En termes généraux, qui était impliqué?",
+  "I’m not sure": "Je ne suis pas certain(e)",
+  "Next": "Suivant",
+  "Other": "Autre",
+  "Phone": "Téléphone",
+  "Please complete the form to tell us what was affected.": "Veuillez remplir le formulaire pour nous dire ce qui a été touché.",
+  "Please complete the text box to tell us how you were affected.": "Veuillez remplir la zone de texte pour nous dire comment vous avez été touché.",
+  "Please complete the text box to tell us what happened.": "Veuillez remplir la zone de texte pour nous dire ce qui s'est passé.",
+  "Please do not provide any personal information.": "Veuillez ne pas fournir de renseignements personnels.",
+  "Privacy": "Confidentialité",
+  "Select where you encountered the cybercrime.": "Veuillez sélectionner où vous avez rencontré la cybercriminalité.",
+  "Share how you were impacted.": "Partagez comment vous avez été affecté.",
+  "Share your story→": "Partagez votre histoire→",
+  "Social media accounts": "Comptes de médias sociaux",
+  "Tell us your story in three easy steps:": "Racontez-nous votre histoire en trois étapes faciles:",
+  "Terms and Conditions": "Avis",
+  "Text messages": "Messages texte",
+  "Thank you for sharing your story.": "Merci d'avoir partagé votre histoire.",
+  "Was your reputation or productivity affected?": "Votre réputation ou votre productivité ont-elles été affectées?",
+  "Website": "Site web",
+  "What Happened": "Qu'est-ce qui s'est passé?",
+  "What is a cybercrime?": "Qu'est-ce qu'un cybercrime?",
+  "What was affected? Choose all that apply.": "Qu'est-ce qui a été affecté? Cochez toutes les réponses qui s'appliquent.",
+  "What was your reaction?": "Quelle a été votre réaction?",
+  "When did it take place?": "Quand cela s'est-il passé?",
+  "You are the {0}th person to use this tool to share a cybercrime story.": "Vous êtes la {0}e personne à utiliser cet outil pour partager une histoire de cybercriminalité.",
+  "loading...": "chargement en cours..."
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,7 +91,7 @@
       "build"
     ],
     "sourceLocale": "en",
-    "format": "lingui"
+    "format": "minimal"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
Instead of the default records that look like
```
  "Bank accounts": {
    "translation": "Comptes bancaires",
    "origin": [["src/Screen2.js", 122]]
  },
  "Describe what happened": {
    "translation": "Décrivez ce qui s'est passé",
    "origin": [["src/Screen1.js", 41]]
},
```
use the minimal style, which looks like
```
  "Bank accounts": "Comptes bancaires",
  "Describe what happened": "Décrivez ce qui s'est passé",
```

This will make PRs that change these files less annoying in that they will not have all the line # changes in them.

Also deleted the `.linguirc` file while I was at it, as lingui is being configured in `package.json`.