### PR TITLE
Refactor lists to accept listStyleType prop

### DIFF
--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro'
 import { Link } from '@reach/router'
 import { H1, H2 } from './components/header'
 import { P } from './components/paragraph'
-import { Ul } from './components/unordered-list'
+import { Ol } from './components/ordered-list'
 import { Li } from './components/list-item'
 import { Query } from 'react-apollo'
 import { GET_LANGUAGE_QUERY } from './utils/queriesAndMutations'
@@ -29,7 +29,7 @@ export const LandingPage = () => (
           <Trans>Tell us your story in three easy steps:</Trans>
         </H2>
         <TrackPageViews />
-        <Ul>
+        <Ol>
           <Li>
             <Trans>Describe what happened.</Trans>
           </Li>{' '}
@@ -39,7 +39,7 @@ export const LandingPage = () => (
           <Li>
             <Trans>Share how you were impacted.</Trans>
           </Li>
-        </Ul>
+        </Ol>
         <P color="green" fontWeight="bolder">
           <Trans>Please do not provide any personal information.</Trans>
         </P>

--- a/frontend/src/__tests__/OrderedList.test.js
+++ b/frontend/src/__tests__/OrderedList.test.js
@@ -29,4 +29,14 @@ describe('Ordered List', () => {
       div,
     )
   })
+
+  it('OL accepts a listStyleType prop', () => {
+    const div = document.createElement('div')
+    ReactDOM.render(
+      <ThemeProvider theme={theme}>
+        <Ol listStyleType="lower-roman">{example}</Ol>
+      </ThemeProvider>,
+      div,
+    )
+  })
 })

--- a/frontend/src/__tests__/UnorderedList.test.js
+++ b/frontend/src/__tests__/UnorderedList.test.js
@@ -2,12 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { ThemeProvider } from 'emotion-theming'
 import theme from '../theme'
-import {
-  UnorderedList,
-  Ul,
-  UlNone,
-  UlSquare,
-} from '../components/unordered-list'
+import { UnorderedList, Ul } from '../components/unordered-list'
 
 describe('Unordered List', () => {
   const example = 'example'
@@ -24,24 +19,12 @@ describe('Unordered List', () => {
     </ThemeProvider>
   )
 
-  it('renders an UnorderedList, Ul, UlNone & UlSquare component without crashing', () => {
+  it('renders an UnorderedList and Ul component without crashing', () => {
     const div = document.createElement('div')
     ReactDOM.render(wrapper, div)
     ReactDOM.render(
       <ThemeProvider theme={theme}>
         <Ul>{example}</Ul>
-      </ThemeProvider>,
-      div,
-    )
-    ReactDOM.render(
-      <ThemeProvider theme={theme}>
-        <UlNone>{example}</UlNone>
-      </ThemeProvider>,
-      div,
-    )
-    ReactDOM.render(
-      <ThemeProvider theme={theme}>
-        <UlSquare>{example}</UlSquare>
       </ThemeProvider>,
       div,
     )

--- a/frontend/src/__tests__/UnorderedList.test.js
+++ b/frontend/src/__tests__/UnorderedList.test.js
@@ -29,4 +29,15 @@ describe('Unordered List', () => {
       div,
     )
   })
+
+  it('UL accepts a listStyleType prop', () => {
+    const div = document.createElement('div')
+    ReactDOM.render(wrapper, div)
+    ReactDOM.render(
+      <ThemeProvider theme={theme}>
+        <Ul listStyleType="square">{example}</Ul>
+      </ThemeProvider>,
+      div,
+    )
+  })
 })

--- a/frontend/src/components/ordered-list/presets.js
+++ b/frontend/src/components/ordered-list/presets.js
@@ -1,19 +1,36 @@
 import React from 'react'
 import { OrderedList } from '.'
 import PropTypes from 'prop-types'
+import { css } from '@emotion/core'
 
-export const Ol = props => (
-  <OrderedList
-    fontSize={[1, null, 2]}
-    lineHeight={[1, null, 2]}
-    pl={[5, null, 6]}
-    mb={4}
-    {...props}
-  >
-    {props.children}
-  </OrderedList>
-)
+export const Ol = props => {
+  const { listStyleType, ...rest } = props
+  var paddingValue
+
+  if (listStyleType === 'none') paddingValue = 0
+  else paddingValue = [5, null, 6]
+
+  return (
+    <OrderedList
+      fontSize={[1, null, 2]}
+      lineHeight={[1, null, 2]}
+      pl={paddingValue}
+      mb={4}
+      css={css`
+        list-style-type: ${listStyleType};
+      `}
+      {...rest}
+    >
+      {props.children}
+    </OrderedList>
+  )
+}
+
+Ol.defaultProps = {
+  listStyleType: 'number',
+}
 
 Ol.propTypes = {
+  listStyleType: PropTypes.string,
   children: PropTypes.any,
 }

--- a/frontend/src/components/unordered-list/index.js
+++ b/frontend/src/components/unordered-list/index.js
@@ -20,4 +20,4 @@ UnorderedList.propTypes = {
   ...fontWeight.propTypes,
 }
 
-export { Ul, UlNone, UlSquare } from './presets'
+export { Ul } from './presets'

--- a/frontend/src/components/unordered-list/presets.js
+++ b/frontend/src/components/unordered-list/presets.js
@@ -3,55 +3,34 @@ import PropTypes from 'prop-types'
 import { UnorderedList } from '.'
 import { css } from '@emotion/core'
 
-export const Ul = props => (
-  <UnorderedList
-    fontSize={[2, null, 3]}
-    lineHeight={[2, null, 3]}
-    pl={[5, null, 6]}
-    mb={4}
-    {...props}
-  >
-    {props.children}
-  </UnorderedList>
-)
+export const Ul = props => {
+  const { listStyleType, ...rest } = props
+  var paddingValue
+
+  if (listStyleType === 'none') paddingValue = 0
+  else paddingValue = [5, null, 6]
+
+  return (
+    <UnorderedList
+      fontSize={[2, null, 3]}
+      lineHeight={[2, null, 3]}
+      pl={paddingValue}
+      mb={4}
+      css={css`
+        list-style-type: ${listStyleType};
+      `}
+      {...rest}
+    >
+      {props.children}
+    </UnorderedList>
+  )
+}
+
+Ul.defaultProps = {
+  listStyleType: 'disc',
+}
 
 Ul.propTypes = {
-  children: PropTypes.any,
-}
-
-export const UlNone = props => (
-  <UnorderedList
-    fontSize={[2, null, 3]}
-    lineHeight={[2, null, 3]}
-    mb={4}
-    css={css`
-      list-style-type: none;
-    `}
-    {...props}
-  >
-    {props.children}
-  </UnorderedList>
-)
-
-UlNone.propTypes = {
-  children: PropTypes.any,
-}
-
-export const UlSquare = props => (
-  <UnorderedList
-    fontSize={[2, null, 3]}
-    lineHeight={[2, null, 3]}
-    mb={4}
-    pl={[5, null, 6]}
-    css={css`
-      list-style-type: square;
-    `}
-    {...props}
-  >
-    {props.children}
-  </UnorderedList>
-)
-
-UlSquare.propTypes = {
+  listStyleType: PropTypes.string,
   children: PropTypes.any,
 }


### PR DESCRIPTION
@sastels made a really good point that being able to pass listStyleType as a prop would be much nicer syntax, so... here it is! Now both Ordered and Unordered lists will accept any legitimate list style type (https://www.w3schools.com/cssref/pr_list-style-type.asp) as a prop, but default to number and disc respectively (since these are by far the most used types. Passing in none results in a special list with no left padding. 

Also I tested ordered lists on the landing page and realized.... I really like it as an ordered list, since it's a step by step list! So I left it in :) 