### PR TITLE
Add Link components & hoc

### DIFF
--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import { Trans } from '@lingui/macro'
 import { A, Link } from './components/link'
 import { H1, H2 } from './components/header'
-import { P } from './components/paragraph'
+import { P, Lead } from './components/paragraph'
 import { Ol } from './components/ordered-list'
 import { Li } from './components/list-item'
 import { Query } from 'react-apollo'
@@ -13,9 +13,6 @@ import { TrackPageViews } from './TrackPageViews'
 const CenterContent = styled('div')`
   max-width: 750px;
   margin: auto;
-`
-const CybercrimeLink = styled('div')`
-  padding-top: 20pt;
 `
 
 export const LandingPage = () => (
@@ -40,13 +37,15 @@ export const LandingPage = () => (
             <Trans>Share how you were impacted.</Trans>
           </Li>
         </Ol>
-        <P color="green" fontWeight="bolder">
+        <Lead color="green" fontWeight="bolder">
           <Trans>Please do not provide any personal information.</Trans>
+        </Lead>
+        <P mt={6}>
+          <Link fontSize={[3, null, 4]} lineHeight={[3, null, 4]} to={'form1'}>
+            <Trans>Share your story→ </Trans>
+          </Link>
         </P>
-        <Link to={'form1'}>
-          <Trans>Share your story→ </Trans>
-        </Link>
-        <CybercrimeLink>
+        <P mt={4}>
           <A
             href={
               language === 'en'
@@ -56,7 +55,7 @@ export const LandingPage = () => (
           >
             <Trans>What is a cybercrime?</Trans>
           </A>
-        </CybercrimeLink>
+        </P>
       </CenterContent>
     )}
   </Query>

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import styled from '@emotion/styled'
 import { Trans } from '@lingui/macro'
-import { Link } from '@reach/router'
+import { Link } from './components/link'
 import { H1, H2 } from './components/header'
 import { P } from './components/paragraph'
 import { Ul } from './components/unordered-list'
 import { Li } from './components/list-item'
+import { asAnchor } from './utils/asAnchor'
 import { Query } from 'react-apollo'
 import { GET_LANGUAGE_QUERY } from './utils/queriesAndMutations'
 import { TrackPageViews } from './TrackPageViews'
@@ -17,6 +18,8 @@ const CenterContent = styled('div')`
 const CybercrimeLink = styled('div')`
   padding-top: 20pt;
 `
+
+const StyledLink = asAnchor('a')
 
 export const LandingPage = () => (
   <Query query={GET_LANGUAGE_QUERY}>
@@ -47,7 +50,7 @@ export const LandingPage = () => (
           <Trans>Share your story→ </Trans>
         </Link>
         <CybercrimeLink>
-          <a
+          <StyledLink
             href={
               language === 'en'
                 ? 'http://www.rcmp-grc.gc.ca/en/cybercrime-an-overview-incidents-and-issues-canada'
@@ -55,7 +58,7 @@ export const LandingPage = () => (
             }
           >
             <Trans>What is a cybercrime?</Trans>
-          </a>
+          </StyledLink>
         </CybercrimeLink>
       </CenterContent>
     )}

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -1,12 +1,11 @@
 import React from 'react'
 import styled from '@emotion/styled'
 import { Trans } from '@lingui/macro'
-import { Link } from './components/link'
+import { A, Link } from './components/link'
 import { H1, H2 } from './components/header'
 import { P } from './components/paragraph'
 import { Ul } from './components/unordered-list'
 import { Li } from './components/list-item'
-import { asAnchor } from './utils/asAnchor'
 import { Query } from 'react-apollo'
 import { GET_LANGUAGE_QUERY } from './utils/queriesAndMutations'
 import { TrackPageViews } from './TrackPageViews'
@@ -18,8 +17,6 @@ const CenterContent = styled('div')`
 const CybercrimeLink = styled('div')`
   padding-top: 20pt;
 `
-
-const StyledLink = asAnchor('a')
 
 export const LandingPage = () => (
   <Query query={GET_LANGUAGE_QUERY}>
@@ -50,7 +47,7 @@ export const LandingPage = () => (
           <Trans>Share your story→ </Trans>
         </Link>
         <CybercrimeLink>
-          <StyledLink
+          <A
             href={
               language === 'en'
                 ? 'http://www.rcmp-grc.gc.ca/en/cybercrime-an-overview-incidents-and-issues-canada'
@@ -58,7 +55,7 @@ export const LandingPage = () => (
             }
           >
             <Trans>What is a cybercrime?</Trans>
-          </StyledLink>
+          </A>
         </CybercrimeLink>
       </CenterContent>
     )}

--- a/frontend/src/__tests__/Link.test.js
+++ b/frontend/src/__tests__/Link.test.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { ThemeProvider } from 'emotion-theming'
+import theme from '../theme'
+import { Link, A } from '../components/link'
+
+describe('Links', () => {
+  const example = 'example'
+
+  it('Renders a Link and A component without crashing', () => {
+    const div = document.createElement('div')
+    ReactDOM.render(
+      <ThemeProvider theme={theme}>
+        <Link to="/">{example}</Link>
+      </ThemeProvider>,
+      div,
+    )
+    ReactDOM.render(
+      <ThemeProvider theme={theme}>
+        <A href="http://www.google.com">{example}</A>
+      </ThemeProvider>,
+      div,
+    )
+  })
+})

--- a/frontend/src/components/link/index.js
+++ b/frontend/src/components/link/index.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { asAnchor } from '../../utils/asAnchor'
+import { Link as ReachLink } from '@reach/router'
+import PropTypes from 'prop-types'
+
+const BaseLink = asAnchor(ReachLink)
+
+export const Link = props => (
+  <BaseLink
+    fontSize={[2, null, 3]}
+    lineHeight={[2, null, 3]}
+    mb={4}
+    colors="link"
+    {...props}
+  >
+    {props.children}
+  </BaseLink>
+)
+
+Link.propTypes = {
+  children: PropTypes.any,
+}

--- a/frontend/src/components/link/index.js
+++ b/frontend/src/components/link/index.js
@@ -4,6 +4,7 @@ import { Link as ReachLink } from '@reach/router'
 import PropTypes from 'prop-types'
 
 const BaseLink = asAnchor(ReachLink)
+const BaseAnchor = asAnchor('a')
 
 export const Link = props => (
   <BaseLink
@@ -18,5 +19,21 @@ export const Link = props => (
 )
 
 Link.propTypes = {
+  children: PropTypes.any,
+}
+
+export const A = props => (
+  <BaseAnchor
+    fontSize={[2, null, 3]}
+    lineHeight={[2, null, 3]}
+    mb={4}
+    colors="link"
+    {...props}
+  >
+    {props.children}
+  </BaseAnchor>
+)
+
+A.propTypes = {
   children: PropTypes.any,
 }

--- a/frontend/src/utils/asAnchor.js
+++ b/frontend/src/utils/asAnchor.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import {
+  fontSize,
+  lineHeight,
+  space,
+  fontWeight,
+  colorStyle,
+} from 'styled-system'
+import cleanElement from 'clean-element'
+import PropTypes from 'prop-types'
+
+export const asAnchor = AnchorType => {
+  const Anchor = props => <AnchorType {...props}>{props.children}</AnchorType>
+
+  Anchor.propTypes = {
+    children: PropTypes.any,
+  }
+
+  const CleanAnchor = cleanElement(Anchor)
+
+  CleanAnchor.propTypes = {
+    ...fontSize.propTypes,
+    ...lineHeight.propTypes,
+    ...space.propTypes,
+    ...colorStyle.propTypes,
+    ...fontWeight.propTypes,
+  }
+
+  const StyledAnchor = styled(CleanAnchor)`
+    font-family: ${({ theme }) => theme.fontSans};
+    margin: 0;
+    ${fontSize};
+    ${lineHeight};
+    ${space};
+    ${colorStyle};
+    ${fontWeight};
+  `
+  return StyledAnchor
+}


### PR DESCRIPTION
This PR adds: 

- asAnchor, an HoC that is used to return a styleable link component
- Link, a styleable Reach Router Link created using asAnchor
- A, a styleable anchor created using asAnchor