### PR TITLE
add styled Text component

### DIFF
--- a/frontend/src/Screen1.js
+++ b/frontend/src/Screen1.js
@@ -4,6 +4,7 @@ import { navigate } from '@reach/router'
 import styled from '@emotion/styled'
 import { Trans } from '@lingui/macro'
 import { H1 } from './components/header'
+import { Text } from './components/text'
 import { ApolloConsumer } from 'react-apollo'
 // import Breadcrumb from '@govuk-react/breadcrumb'
 import { TrackPageViews } from './TrackPageViews'
@@ -36,7 +37,11 @@ export const Screen1 = () => (
         <Trans>Landing Page</Trans>
       </Link>
     </Breadcrumb> */}
-    <div>Placeholder for Breacrumb</div>
+    <div>
+      <Text display="inline-block">Placeholder&nbsp;</Text>
+      <Text display="inline-block">for</Text>
+      <Text fontSize={[4, 4, 5]}>Breadcrumb</Text>
+    </div>
     <H1>
       <Trans>Describe what happened</Trans>
     </H1>

--- a/frontend/src/__tests__/Text.test.js
+++ b/frontend/src/__tests__/Text.test.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { ThemeProvider } from 'emotion-theming'
+import theme from '../theme'
+import { Text } from '../components/text'
+
+describe('Text', () => {
+  const example = 'example'
+
+  it('Renders a Text component preset without crashing', () => {
+    const div = document.createElement('div')
+    ReactDOM.render(
+      <ThemeProvider theme={theme}>
+        <Text>{example}</Text>
+      </ThemeProvider>,
+      div,
+    )
+  })
+})

--- a/frontend/src/components/text/index.js
+++ b/frontend/src/components/text/index.js
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled'
+import {
+  display,
+  fontSize,
+  lineHeight,
+  space,
+  color,
+  fontWeight,
+} from 'styled-system'
+import tag from 'clean-tag'
+
+export const StyledDiv = styled(tag.div)`
+  font-family: ${({ theme }) => theme.fontSans};
+  margin: 0;
+  ${display};
+  ${fontSize};
+  ${lineHeight};
+  ${space};
+  ${color};
+  ${fontWeight};
+`
+
+StyledDiv.propTypes = {
+  ...display.propTypes,
+  ...fontSize.propTypes,
+  ...lineHeight.propTypes,
+  ...space.propTypes,
+  ...color.propTypes,
+  ...fontWeight.propTypes,
+}
+
+export { Text } from './presets'

--- a/frontend/src/components/text/presets.js
+++ b/frontend/src/components/text/presets.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { StyledDiv } from '.'
+import PropTypes from 'prop-types'
+
+export const Text = props => (
+  <StyledDiv
+    display="block"
+    fontSize={[2, null, 3]}
+    lineHeight={[2, null, 3]}
+    mb={4}
+    color="black"
+    {...props}
+  >
+    {props.children}
+  </StyledDiv>
+)
+
+Text.propTypes = {
+  children: PropTypes.any,
+}


### PR DESCRIPTION
a styled div. Uses paragraph defaults, can also give it a `display` prop to override the default `block` styling (ie for inline text)

Example in breadcrumb text on first form ("Placeholder" and "for" are inline, "Breadcrumb" is default and bigger)