### PR TITLE
disable service workers unless in production

### DIFF
--- a/frontend/src/server.js
+++ b/frontend/src/server.js
@@ -11,6 +11,8 @@ import App from './App'
 
 let assets, publicDir
 
+const inProductionEnvironment = process.env.NODE_ENV === 'production'
+
 if (process.env.NODE_ENV === 'test') {
   assets = { client: { css: {} } }
   publicDir = 'public'
@@ -72,7 +74,7 @@ server
                 : ''
             }
             ${
-              process.env.NODE_ENV === 'production'
+              inProductionEnvironment
                 ? `<script src="${assets.client.js}" defer></script>`
                 : `<script src="${
                     assets.client.js
@@ -89,13 +91,17 @@ server
           </head>
           <body>
             <div id="root">${markup}</div>
-             <script>
-                if ('serviceWorker' in navigator) {
-                  window.addEventListener('load', () => {
-                    navigator.serviceWorker.register('service-worker.js')
-                  });
-                }
-             </script>
+            ${
+              inProductionEnvironment
+                ? `<script>
+                  if ('serviceWorker' in navigator) {
+                    window.addEventListener('load', () => {
+                      navigator.serviceWorker.register('service-worker.js')
+                    });
+                  }
+                </script>`
+                : ''
+            }
           </body>
         </html>
       `)


### PR DESCRIPTION
Resolves #150 

Note that you might have to also manually unregister the old service worker for localhost from your browser. (that are lurking around from the last time you ran locally). They're a tough beast to get rid of.