### PR TITLE
Add a Container component

### DIFF
--- a/frontend/src/components/container/__tests__/Container.test.js
+++ b/frontend/src/components/container/__tests__/Container.test.js
@@ -5,7 +5,6 @@ import { render, cleanup } from 'react-testing-library'
 
 describe('<Container />', () => {
   afterEach(cleanup)
-  // const example = 'example'
 
   it('properly renders child components', () => {
     const { getAllByText } = render(

--- a/frontend/src/components/container/__tests__/Container.test.js
+++ b/frontend/src/components/container/__tests__/Container.test.js
@@ -1,0 +1,116 @@
+import React from 'react'
+import { ThemeProvider } from 'emotion-theming'
+import { Container } from '../'
+import { render, cleanup } from 'react-testing-library'
+
+describe('<Container />', () => {
+  afterEach(cleanup)
+  // const example = 'example'
+
+  it('properly renders child components', () => {
+    const { getAllByText } = render(
+      <Container>
+        <p>foo</p>
+      </Container>,
+    )
+
+    const test = getAllByText(/foo/)
+    expect(test).toHaveLength(1)
+  })
+
+  it('properly handles border props', () => {
+    const { getByText } = render(
+      <ThemeProvider theme={{ colors: { blue: '#005ea5' } }}>
+        <Container border="1px solid" borderColor="blue">
+          test
+        </Container>
+      </ThemeProvider>,
+    )
+
+    const test = getByText(/test/)
+    expect(test).toHaveStyleRule('border', '1px solid')
+    expect(test).toHaveStyleRule('border-color', '#005ea5')
+  })
+
+  it('properly handles color props', () => {
+    const { getByText } = render(
+      <ThemeProvider theme={{ colors: { blue: '#005ea5' } }}>
+        <Container bg="blue" color="blue">
+          test
+        </Container>
+      </ThemeProvider>,
+    )
+
+    const test = getByText(/test/)
+    expect(test).toHaveStyleRule('background-color', '#005ea5')
+    expect(test).toHaveStyleRule('color', '#005ea5')
+  })
+
+  it('properly handles dimension props', () => {
+    const { getByText } = render(
+      <Container width={400} height="2rem">
+        test
+      </Container>,
+    )
+
+    const test = getByText(/test/)
+    expect(test).toHaveStyleRule('width', '400px')
+    expect(test).toHaveStyleRule('height', '2rem')
+  })
+
+  it('properly handles space props', () => {
+    const SPACING = ['0px', '5px']
+    const { getByText } = render(
+      <ThemeProvider theme={{ space: SPACING }}>
+        <Container m="auto" ml={1} p={0} px={1}>
+          test
+        </Container>
+      </ThemeProvider>,
+    )
+
+    const test = getByText(/test/)
+    expect(test).toHaveStyleRule('margin', 'auto')
+    expect(test).toHaveStyleRule('margin-left', '5px')
+    expect(test).toHaveStyleRule('padding', '0px')
+    expect(test).toHaveStyleRule('padding-left', '5px')
+    expect(test).toHaveStyleRule('padding-right', '5px')
+  })
+
+  it('properly handles layout props', () => {
+    const { getByText } = render(
+      <Container display="inline-block">test</Container>,
+    )
+
+    const test = getByText(/test/)
+    expect(test).toHaveStyleRule('display', 'inline-block')
+  })
+
+  it('properly handles flexbox props', () => {
+    const { getByText } = render(
+      <Container
+        alignItems="center"
+        alignContent="left"
+        justifyContent="right"
+        flexWrap="wrap"
+        flexBasis="auto"
+        flexDirection="column"
+        flex="0 0 auto"
+        justifySelf="center"
+        alignSelf="center"
+      >
+        test
+      </Container>,
+    )
+
+    const test = getByText(/test/)
+    expect(test).toHaveStyleRule('align-items', 'center')
+    expect(test).toHaveStyleRule('align-content', 'left')
+    expect(test).toHaveStyleRule('justify-content', 'right')
+    expect(test).toHaveStyleRule('flex-wrap', 'wrap')
+    expect(test).toHaveStyleRule('flex-basis', 'auto')
+    expect(test).toHaveStyleRule('flex-direction', 'column')
+    expect(test).toHaveStyleRule('flex', '0 0 auto')
+    expect(test).toHaveStyleRule('justify-self', 'center')
+    expect(test).toHaveStyleRule('align-self', 'center')
+  })
+})

--- a/frontend/src/components/container/index.js
+++ b/frontend/src/components/container/index.js
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled'
+import {
+  alignItems,
+  alignContent,
+  justifyContent,
+  flexWrap,
+  flexBasis,
+  flexDirection,
+  width,
+  height,
+  color,
+  borders,
+  borderColor,
+  flex,
+  justifySelf,
+  display,
+  alignSelf,
+  space,
+} from 'styled-system'
+import tag from 'clean-tag'
+
+export const Container = styled(tag.div)`
+  ${alignItems}
+  ${alignContent}
+  ${justifyContent}
+  ${flex}
+  ${flexWrap}
+  ${flexBasis}
+  ${flexDirection}
+  ${width}
+  ${height}
+  ${color}
+  ${display}
+  ${space}
+  ${justifySelf}
+  ${alignSelf}
+  ${borders}
+  ${borderColor}
+`
+
+Container.propTypes = {
+  ...alignItems.propTypes,
+  ...alignContent.propTypes,
+  ...justifyContent.propTypes,
+  ...flex.propTypes,
+  ...flexWrap.propTypes,
+  ...flexBasis.propTypes,
+  ...flexDirection.propTypes,
+  ...width.propTypes,
+  ...height.propTypes,
+  ...color.propTypes,
+  ...display.propTypes,
+  ...space.propTypes,
+  ...justifySelf.propTypes,
+  ...alignSelf.propTypes,
+  ...borders.propTypes,
+  ...borderColor.propTypes,
+}


### PR DESCRIPTION
This PR adds a general use styled div called Container, used to uh, contain... things. I've added the props necessary to handle my upcoming Top Header component, mostly flexbox and basic height/width things. We will likely need to add onto this in the future for more complex layouting, but this gives us a start. Also, check out them tests ;) 