### PR TITLE
Add Top Banner component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,31 +4,12 @@ import { Global, css } from '@emotion/core'
 import { ThemeProvider } from 'emotion-theming'
 import theme from './theme'
 import { Query } from 'react-apollo'
-import PropTypes from 'prop-types'
 import { Helmet } from 'react-helmet'
 import WordMark from './components/wordmark'
-import GoCSignature from './components/gocsig'
 import Home from './Home'
-import { LanguageSwitcher } from './LanguageSwitcher'
 import { Trans } from '@lingui/macro'
 import { GET_LANGUAGE_QUERY } from './utils/queriesAndMutations'
-
-const FipBanner = styled('div')`
-  background-color: black;
-  margin: auto;
-  padding: 10px;
-  height: 40px;
-`
-const Flag = styled('div')`
-  float: left;
-  padding: 5px;
-  width: 300px;
-`
-const LanguageButton = styled('div')`
-  display: inline-block;
-  float: right;
-  margin-top: 10px;
-`
+import { TopBanner } from './components/topbanner'
 
 const Footer = styled('div')`
   background-color: black;
@@ -56,22 +37,6 @@ const Content = styled('div')`
   min-height: calc(100vh - 55px);
 `
 
-const TopBanner = props => (
-  <FipBanner>
-    <Flag>
-      <GoCSignature width="100%" lang={props.lang} flag="#fff" text="#fff" />
-    </Flag>
-
-    <LanguageButton>
-      <LanguageSwitcher />
-    </LanguageButton>
-  </FipBanner>
-)
-
-TopBanner.propTypes = {
-  lang: PropTypes.string,
-}
-
 const App = () => (
   <Query query={GET_LANGUAGE_QUERY}>
     {({ data: { language } }) => (
@@ -89,7 +54,7 @@ const App = () => (
         />
         <ThemeProvider theme={theme}>
           <Content>
-            <TopBanner lang={language} />
+            <TopBanner lang={language} bg="black" />
             <Home />
           </Content>
 

--- a/frontend/src/components/topbanner/__tests__/TopBanner.test.js
+++ b/frontend/src/components/topbanner/__tests__/TopBanner.test.js
@@ -36,4 +36,18 @@ describe('<TopBanner />', () => {
     const test = getByTestId('background-color')
     expect(test).toHaveStyleRule('background-color', '#005ea5')
   })
+
+  it('renders with a black bg if no bg color prop specified', () => {
+    const englishClient = testClient({ language: 'en' })
+
+    const { getByTestId } = render(
+      <ApolloProvider client={englishClient}>
+        <ThemeProvider theme={{ colors: { black: '#000000' } }}>
+          <TopBanner lang="en" />
+        </ThemeProvider>
+      </ApolloProvider>,
+    )
+    const test = getByTestId('background-color')
+    expect(test).toHaveStyleRule('background-color', '#000000')
+  })
 })

--- a/frontend/src/components/topbanner/__tests__/TopBanner.test.js
+++ b/frontend/src/components/topbanner/__tests__/TopBanner.test.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { ThemeProvider } from 'emotion-theming'
+import theme from '../../../theme'
+import { TopBanner } from '../'
+import { render, cleanup } from 'react-testing-library'
+import { testClient } from '../../../utils/createTestClient'
+import { ApolloProvider } from 'react-apollo'
+
+describe('<TopBanner />', () => {
+  afterEach(cleanup)
+
+  it('renders using the language prop correctly', () => {
+    const englishClient = testClient({ language: 'en' })
+
+    const { getByRole } = render(
+      <ApolloProvider client={englishClient}>
+        <ThemeProvider theme={theme}>
+          <TopBanner lang="en" />
+        </ThemeProvider>
+      </ApolloProvider>,
+    )
+    const test = getByRole('img')
+    expect(test.getAttribute('aria-label')).toBe('Government of Canada')
+  })
+
+  it('renders using the bg color prop correctly', () => {
+    const englishClient = testClient({ language: 'en' })
+
+    const { getByTestId } = render(
+      <ApolloProvider client={englishClient}>
+        <ThemeProvider theme={{ colors: { blue: '#005ea5' } }}>
+          <TopBanner lang="en" bg="blue" />
+        </ThemeProvider>
+      </ApolloProvider>,
+    )
+    const test = getByTestId('background-color')
+    expect(test).toHaveStyleRule('background-color', '#005ea5')
+  })
+})

--- a/frontend/src/components/topbanner/index.js
+++ b/frontend/src/components/topbanner/index.js
@@ -1,0 +1,48 @@
+import PropTypes from 'prop-types'
+/** @jsx jsx **/
+import { jsx, css } from '@emotion/core'
+import { Container } from '../container'
+import GoCSignature from '../gocsig'
+import { LanguageSwitcher } from '../../LanguageSwitcher'
+
+export const TopBanner = props => {
+  const { lang, bg } = props
+
+  return (
+    <Container
+      bg={bg}
+      display="flex"
+      flexDirection="row"
+      width={1}
+      height={[50, null, 60]}
+      alignItems="center"
+      data-testid="background-color"
+    >
+      <Container ml={3} width={[250, null, 300]}>
+        <GoCSignature
+          width="100%"
+          lang={lang}
+          flag="#fff"
+          text="#fff"
+          css={css`
+            display: block;
+          `}
+        />
+      </Container>
+      <Container
+        flex="1 1 auto"
+        mr={3}
+        css={css`
+          text-align: right;
+        `}
+      >
+        <LanguageSwitcher />
+      </Container>
+    </Container>
+  )
+}
+
+TopBanner.propTypes = {
+  lang: PropTypes.string,
+  bg: PropTypes.string,
+}

--- a/frontend/src/components/topbanner/index.js
+++ b/frontend/src/components/topbanner/index.js
@@ -43,6 +43,10 @@ export const TopBanner = props => {
 }
 
 TopBanner.propTypes = {
-  lang: PropTypes.string,
+  lang: PropTypes.string.isRequired,
   bg: PropTypes.string,
+}
+
+TopBanner.defaultProps = {
+  bg: 'black',
 }


### PR DESCRIPTION
_finally_

This PR adds a responsive Top Banner component using the Container, GoCSig & LanguageSwitcher components. Discussed the issues of aria-label/aria-describedby/alt text etc with @JuliannaR, there's some kind of issue there with the screen reader not picking up the SVG as an image, but that's something we an solve down the line when we swap out for the RCMP logo and potentially add a link back to the RCMP website, changing the behaviour. 