### PR TITLE
downgrade node version in cloudbuild tests to fix master

### DIFF
--- a/frontend/cloudbuild.yaml
+++ b/frontend/cloudbuild.yaml
@@ -11,7 +11,7 @@ steps:
     entrypoint: npm
     args: ['run', 'compile']
 
-  - name: node:11-alpine
+  - name: node:11.10-alpine
     id: test
     dir: frontend
     entrypoint: npm


### PR DESCRIPTION
jest breaking on CI. Downgraded node on testing to 11.10-alpine, as per
https://github.com/facebook/create-react-app/issues/6591