### PR TITLE
roll back node version in api, new version breaks jest

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
     entrypoint: npm
     args: ['ci']
 
-  - name: node:11-alpine
+  - name: node:11.10-alpine
     dir: api
     entrypoint: npm
     args: ['test']


### PR DESCRIPTION
jest breaking on CI. Downgraded node on testing to 11.10-alpine, as per
facebook/create-react-app#6591