### PR TITLE
Add config to enable import linting

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["react", "react-hooks"],
+  "plugins": ["react", "react-hooks", "import"],
   "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 6,
@@ -15,7 +15,12 @@
     "mocha": true,
     "jest": true
   },
-  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings"
+  ],
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn"


### PR DESCRIPTION
Import plugin rules were off by default, so while we had this plugin installed
it wasn't functioning. This commit adds the necessary options to our eslint
config.