### PR TITLE
Added jsx-a11y Linter 

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -24,7 +24,11 @@
   ],
   "rules": {
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+    "jsx-a11y/label-has-associated-control": [
+      2,
+      { "controlComponents": ["Input", "TextArea"] }
+    ]
   },
   "settings": {
     "react": {

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["react", "react-hooks", "import"],
+  "plugins": ["react", "react-hooks", "import", "jsx-a11y"],
   "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 6,
@@ -19,7 +19,8 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:import/errors",
-    "plugin:import/warnings"
+    "plugin:import/warnings",
+    "plugin:jsx-a11y/recommended"
   ],
   "rules": {
     "react-hooks/rules-of-hooks": "error",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,6 +77,7 @@
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jest": "^22.3.0",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.12.4",

--- a/frontend/src/Screen2.js
+++ b/frontend/src/Screen2.js
@@ -69,7 +69,7 @@ const MyForm = options => (
           <form onSubmit={handleSubmit}>
             <div>
               <LabelFormat>
-                <label>
+                <label htmlFor="whatWasInvolved">
                   <Trans>What was affected? Choose all that apply.</Trans>
                 </label>
               </LabelFormat>
@@ -78,6 +78,7 @@ const MyForm = options => (
                   return (
                     <CheckboxStyle key={key}>
                       <Field
+                        id="whatWasInvolved"
                         name="whatWasInvolved"
                         component={CheckboxAdapter}
                         type="checkbox"
@@ -90,12 +91,12 @@ const MyForm = options => (
               </div>
             </div>
             <LabelFormat>
-              <label>
+              <label htmlFor="whatWasInvolvedOther">
                 <Trans>Other</Trans>
               </label>
             </LabelFormat>
             <div>
-              <Field name="whatWasInvolvedOther">
+              <Field id="whatWasInvolvedOther" name="whatWasInvolvedOther">
                 {({ input, meta }) => (
                   <div>
                     <TextArea {...input} placeholder="" />

--- a/frontend/src/components/input/__tests__/Input.test.js
+++ b/frontend/src/components/input/__tests__/Input.test.js
@@ -10,7 +10,10 @@ describe('<Input />', () => {
   it('renders component in HTML as an input tag', () => {
     let wrapper = mount(
       <form>
-        <label>Test</label> <Input />
+        <label>
+          Test
+          <Input />
+        </label>
       </form>,
     ).find('input')
     expect(wrapper.is('input')).toBeTruthy()
@@ -19,8 +22,13 @@ describe('<Input />', () => {
   it('uses the dimension props to set height and width in CSS', () => {
     const { getByLabelText } = render(
       <form>
-        <label id="test">Test</label>{' '}
-        <Input aria-labelledby="test" height={300} width="2rem" />{' '}
+        <label htmlFor="test">Test</label>
+        <Input
+          id="test"
+          aria-labelledby="test"
+          height={300}
+          width="2rem"
+        />{' '}
       </form>,
     )
 
@@ -34,8 +42,15 @@ describe('<Input />', () => {
     const { getByLabelText } = render(
       <ThemeProvider theme={{ space: SPACING }}>
         <form>
-          <label id="test">Test</label>{' '}
-          <Input aria-labelledby="test" m="auto" ml={1} p={0} px={1} />{' '}
+          <label htmlFor="test">Test</label>{' '}
+          <Input
+            id="test"
+            aria-labelledby="test"
+            m="auto"
+            ml={1}
+            p={0}
+            px={1}
+          />{' '}
         </form>
       </ThemeProvider>,
     )
@@ -52,8 +67,8 @@ describe('<Input />', () => {
     const { getByLabelText } = render(
       <ThemeProvider theme={{ colors: { blue: '#005ea5' } }}>
         <form>
-          <label id="test">Test</label>{' '}
-          <Input aria-labelledby="test" border="1px solid" borderColor="blue" />{' '}
+          <label htmlFor="test">Test</label>{' '}
+          <Input id="test" border="1px solid" borderColor="blue" />{' '}
         </form>
       </ThemeProvider>,
     )
@@ -66,8 +81,8 @@ describe('<Input />', () => {
   it('uses the layout props to set display type in CSS', () => {
     const { getByLabelText } = render(
       <form>
-        <label id="test">Test</label>{' '}
-        <Input aria-labelledby="test" display="inline-block" />{' '}
+        <label htmlFor="test">Test</label>{' '}
+        <Input id="test" display="inline-block" />{' '}
       </form>,
     )
 
@@ -78,9 +93,9 @@ describe('<Input />', () => {
   it('uses the position props to set type of positioning and positioning values in CSS', () => {
     const { getByLabelText } = render(
       <form>
-        <label id="test">Test</label>{' '}
+        <label htmlFor="test">Test</label>{' '}
         <Input
-          aria-labelledby="test"
+          id="test"
           position="absolute"
           zIndex="1"
           top="1"

--- a/frontend/src/components/text-area/__tests__/TextArea.test.js
+++ b/frontend/src/components/text-area/__tests__/TextArea.test.js
@@ -10,7 +10,10 @@ describe('<TextArea />', () => {
   it('properly renders as a textarea tag', () => {
     let wrapper = mount(
       <form>
-        <label>Test</label> <TextArea />
+        <label>
+          Test
+          <TextArea />
+        </label>
       </form>,
     ).find('textarea')
     expect(wrapper.is('textarea')).toBeTruthy()
@@ -19,9 +22,9 @@ describe('<TextArea />', () => {
   it('sets font properties from props', () => {
     const { getByLabelText } = render(
       <form>
-        <label id="test">Test</label>{' '}
+        <label htmlFor="test">Test</label>{' '}
         <TextArea
-          aria-labelledby="test"
+          id="test"
           fontSize="30px"
           fontWeight={200}
           lineHeight="20pt"
@@ -37,8 +40,8 @@ describe('<TextArea />', () => {
   it('sets height and width from props', () => {
     const { getByLabelText } = render(
       <form>
-        <label id="test">Test</label>{' '}
-        <TextArea aria-labelledby="test" height={300} width="2rem" />{' '}
+        <label htmlFor="test">Test</label>{' '}
+        <TextArea id="test" height={300} width="2rem" />{' '}
       </form>,
     )
     const test = getByLabelText(/Test/)
@@ -51,8 +54,8 @@ describe('<TextArea />', () => {
     const { getByLabelText } = render(
       <ThemeProvider theme={{ space: SPACING }}>
         <form>
-          <label id="test">Test</label>{' '}
-          <TextArea aria-labelledby="test" m="auto" ml={1} p={0} px={1} />{' '}
+          <label htmlFor="test">Test</label>{' '}
+          <TextArea id="test" m="auto" ml={1} p={0} px={1} />{' '}
         </form>
       </ThemeProvider>,
     )
@@ -67,8 +70,8 @@ describe('<TextArea />', () => {
   it('sets display from props', () => {
     const { getByLabelText } = render(
       <form>
-        <label id="test">Test</label>{' '}
-        <TextArea aria-labelledby="test" display="inline-block" />{' '}
+        <label htmlFor="test">Test</label>{' '}
+        <TextArea id="test" display="inline-block" />{' '}
       </form>,
     )
     const test = getByLabelText(/Test/)


### PR DESCRIPTION
This commit/linter is just for testing and exploration purposes to see what can work as a standard Accessibility linter tool.

Notes:
- It will be only tested with all A11y baked in rules within the linter for common aria* validations
- Any custom rules for styled components will be added later with more feedback from the team :) 