### PR TITLE
Fix unfetch dependancy

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21070,8 +21070,7 @@
     "unfetch": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
-      "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==",
-      "dev": true
+      "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,8 @@
     "react-final-form": "^4.1.0",
     "react-ga": "^2.5.7",
     "react-helmet": "^5.2.0",
-    "styled-system": "^4.0.3"
+    "styled-system": "^4.0.3",
+    "unfetch": "^4.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",
@@ -92,7 +93,6 @@
     "prop-types": "^15.7.2",
     "react-testing-library": "^6.0.0",
     "supertest": "^4.0.0",
-    "unfetch": "^4.1.0",
     "waait": "^1.0.4"
   },
   "lingui": {


### PR DESCRIPTION
PR #185 started using the dev dependency `unfetch` in prod code. This PR moves `unfetch` to be a prod dependency.