### PR TITLE
don't cache graphql calls in service-worker

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -44,7 +44,9 @@ self.addEventListener('fetch', function(event) {
     fetch(event.request)
       .then(response => {
         return caches.open(staticCacheName).then(cache => {
-          cache.put(event.request, response.clone())
+          if (event.request.method === 'GET') {
+            cache.put(event.request, response.clone())
+          }
           return response
         })
       })


### PR DESCRIPTION
the graphql POSTs were causing the `service-worker` code to throw an error. In this PR we restrict the caching to GETs.