### PR TITLE
Add Lingui to dev & test command (maybe?)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,11 +4,11 @@
   "license": "MIT",
   "repository": "github:cds-snc/report-a-cybercrime",
   "scripts": {
-    "dev": "razzle start",
+    "dev": "lingui compile && razzle start",
     "build": "lingui compile && razzle build",
     "heroku-postbuild": "NODE_ENV=production lingui extract && lingui compile && razzle build",
     "dbg": "node --inspect-brk node_modules/.bin/jest --runInBand",
-    "test": "jest",
+    "test": "lingui compile && jest",
     "lint": "eslint 'src/**/*.js'",
     "start": "NODE_ENV=production node build/server.js",
     "add-locale": "lingui add-locale",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "lingui compile && razzle build",
     "heroku-postbuild": "NODE_ENV=production lingui extract && lingui compile && razzle build",
     "dbg": "node --inspect-brk node_modules/.bin/jest --runInBand",
-    "test": "lingui compile && jest",
+    "test": "jest",
     "lint": "eslint 'src/**/*.js'",
     "start": "NODE_ENV=production node build/server.js",
     "add-locale": "lingui add-locale",


### PR DESCRIPTION
In this PR I'm adding the Lingui compile step to the dev and test commands. This is to solve an issue where trying to run the app in dev or running certain tests will give weird errors if you forget to compile after cloning, or if another PR changes the messages and you don't compile locally. Compilation doesn't take all that long and solves flaky tests so, maybe worth it?