### PR TITLE
Skip links

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -50,7 +50,7 @@ const App = () => (
           </script>
           <script>
             {`
-                if ('REMOVE_THIS_LATER_serviceWorker' in navigator) {
+                if ('serviceWorker' in navigator) {
                   window.addEventListener('load', () => {
                     navigator.serviceWorker.register('service-worker.js')
                   });

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -50,7 +50,7 @@ const App = () => (
           </script>
           <script>
             {`
-                if ('serviceWorker' in navigator) {
+                if ('REMOVE_THIS_LATER_serviceWorker' in navigator) {
                   window.addEventListener('load', () => {
                     navigator.serviceWorker.register('service-worker.js')
                   });

--- a/frontend/src/Screen1.js
+++ b/frontend/src/Screen1.js
@@ -56,6 +56,8 @@ export const Screen1 = () => (
         />
       )}
     </ApolloConsumer>
-    <SkipLink href="#top">Skip to top</SkipLink>
+    <SkipLink invisible href="#top">
+      Skip to top
+    </SkipLink>
   </Container>
 )

--- a/frontend/src/Screen1.js
+++ b/frontend/src/Screen1.js
@@ -12,6 +12,7 @@ import { Container } from './components/container'
 import { jsx } from '@emotion/core'
 import { Li } from './components/list-item'
 import { Ul } from './components/unordered-list'
+import { SkipLink } from './components/skip-link'
 
 export const Screen1 = () => (
   <Container m="auto" width={[1, 1 / 2, 1 / 4]}>
@@ -23,7 +24,8 @@ export const Screen1 = () => (
         <Trans>What Happened</Trans>
       </Text>
     </Breadcrumb>
-    <H1>
+
+    <H1 id="top" tabIndex="-1">
       <Trans>Describe what happened</Trans>
     </H1>
 
@@ -54,5 +56,6 @@ export const Screen1 = () => (
         />
       )}
     </ApolloConsumer>
+    <SkipLink href="#top">Skip to top</SkipLink>
   </Container>
 )

--- a/frontend/src/components/skip-link/__tests__/SkipLink.test.js
+++ b/frontend/src/components/skip-link/__tests__/SkipLink.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { ThemeProvider } from 'emotion-theming'
+import { render, cleanup } from 'react-testing-library'
+import theme from '../../../theme'
+import { SkipLink } from '..'
+
+describe('SkipLinks', () => {
+  afterEach(cleanup)
+
+  it('Renders a SkipLink without crashing', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <SkipLink to="#top">skip to top</SkipLink>
+      </ThemeProvider>,
+    )
+  })
+})

--- a/frontend/src/components/skip-link/__tests__/SkipLink.test.js
+++ b/frontend/src/components/skip-link/__tests__/SkipLink.test.js
@@ -7,7 +7,7 @@ import { SkipLink } from '..'
 describe('SkipLinks', () => {
   afterEach(cleanup)
 
-  it('Renders without crashing', () => {
+  it('Render without crashing', () => {
     render(
       <ThemeProvider theme={theme}>
         <SkipLink to="#top">skip to top</SkipLink>

--- a/frontend/src/components/skip-link/__tests__/SkipLink.test.js
+++ b/frontend/src/components/skip-link/__tests__/SkipLink.test.js
@@ -7,11 +7,33 @@ import { SkipLink } from '..'
 describe('SkipLinks', () => {
   afterEach(cleanup)
 
-  it('Renders a SkipLink without crashing', () => {
+  it('Renders without crashing', () => {
     render(
       <ThemeProvider theme={theme}>
         <SkipLink to="#top">skip to top</SkipLink>
       </ThemeProvider>,
     )
+  })
+
+  it('are visible by default', () => {
+    const { getByText } = render(
+      <ThemeProvider theme={theme}>
+        <SkipLink to="#top">skip to top</SkipLink>
+      </ThemeProvider>,
+    )
+    const test = getByText(/skip to top/)
+    expect(test).not.toHaveStyle('z-index: -999;')
+  })
+
+  it('are invisible if invisible prop set', () => {
+    const { getByText } = render(
+      <ThemeProvider theme={theme}>
+        <SkipLink invisible to="#top">
+          skip to top
+        </SkipLink>
+      </ThemeProvider>,
+    )
+    const test = getByText(/skip to top/)
+    expect(test).toHaveStyle('z-index: -999;')
   })
 })

--- a/frontend/src/components/skip-link/index.js
+++ b/frontend/src/components/skip-link/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { A } from '../link'
+
+export const SkipLink = props => <A {...props}>{props.children}</A>
+
+SkipLink.propTypes = {
+  children: PropTypes.any,
+}

--- a/frontend/src/components/skip-link/index.js
+++ b/frontend/src/components/skip-link/index.js
@@ -18,8 +18,14 @@ const makeInvisible = css`
     z-index: 999;
   }
 `
-export const SkipLink = props => <A css={makeInvisible} {...props} />
+export const SkipLink = props => (
+  <A css={props.invisible ? makeInvisible : null} {...props} />
+)
 
+SkipLink.defaultProps = {
+  invisible: false,
+}
 SkipLink.propTypes = {
   children: PropTypes.any,
+  invisible: PropTypes.bool,
 }

--- a/frontend/src/components/skip-link/index.js
+++ b/frontend/src/components/skip-link/index.js
@@ -1,8 +1,24 @@
-import React from 'react'
+/** @jsx jsx */
 import PropTypes from 'prop-types'
+import { jsx, css } from '@emotion/core'
 import { A } from '../link'
 
-export const SkipLink = props => <A {...props}>{props.children}</A>
+const makeInvisible = css`
+  left: -999px;
+  position: absolute;
+  top: auto;
+  overflow: hidden;
+  z-index: -999;
+  :focus,
+  :active {
+    left: auto;
+    top: auto;
+    height: auto;
+    overflow: auto;
+    z-index: 999;
+  }
+`
+export const SkipLink = props => <A css={makeInvisible} {...props} />
 
 SkipLink.propTypes = {
   children: PropTypes.any,

--- a/frontend/src/components/skip-link/index.js
+++ b/frontend/src/components/skip-link/index.js
@@ -18,8 +18,8 @@ const makeInvisible = css`
     z-index: 999;
   }
 `
-export const SkipLink = props => (
-  <A css={props.invisible ? makeInvisible : null} {...props} />
+export const SkipLink = ({ invisible, ...rest }) => (
+  <A css={invisible ? makeInvisible : null} {...rest} />
 )
 
 SkipLink.defaultProps = {

--- a/frontend/src/components/skip-link/index.js
+++ b/frontend/src/components/skip-link/index.js
@@ -26,6 +26,5 @@ SkipLink.defaultProps = {
   invisible: false,
 }
 SkipLink.propTypes = {
-  children: PropTypes.any,
   invisible: PropTypes.bool,
 }


### PR DESCRIPTION
resolves #142 

Basically a glorified `<A />`. Adds an `invisible` prop that will make the link invisible if not in focus.

CSS adapted from https://accessibility.oit.ncsu.edu/it-accessibility-at-nc-state/developers/accessibility-handbook/mouse-and-keyboard-events/skip-to-main-content/

Example of usage is at the bottom of the first form of the discovery tool, `/old/form1`