### PR TITLE
Replace Buttons with styled Reach Links

### DIFF
--- a/frontend/src/Page1.js
+++ b/frontend/src/Page1.js
@@ -6,7 +6,6 @@ import { P } from './components/paragraph'
 import { Ul } from './components/unordered-list'
 import { Li } from './components/list-item'
 import { ButtonLink } from './components/link'
-import { Button } from './components/button'
 import { TrackPageViews } from './TrackPageViews'
 import { Counters } from './counters'
 

--- a/frontend/src/Page1.js
+++ b/frontend/src/Page1.js
@@ -5,6 +5,7 @@ import { H1, H2 } from './components/header'
 import { P } from './components/paragraph'
 import { Ul } from './components/unordered-list'
 import { Li } from './components/list-item'
+import { ButtonLink } from './components/link'
 import { Button } from './components/button'
 import { TrackPageViews } from './TrackPageViews'
 import { Counters } from './counters'
@@ -43,15 +44,9 @@ export const Page1 = () => (
       <Trans>We‘ll use this information to investigate.</Trans>
     </P>
 
-    <Button
-      mb={[3, null, 5]}
-      onClick={() => {
-        window.location.href = '/flag'
-      }}
-      value="Continue"
-    >
+    <ButtonLink mb={[3, null, 5]} to="/flag">
       <Trans>Continue</Trans>
-    </Button>
+    </ButtonLink>
 
     <P fontSize={[2, null, 3]}>
       <Trans>Over the past month, people have shared:</Trans>

--- a/frontend/src/Page2.js
+++ b/frontend/src/Page2.js
@@ -13,6 +13,7 @@ import { Container } from './components/container'
 import { jsx, css } from '@emotion/core'
 import { TextArea } from './components/text-area'
 import { Button } from './components/button'
+import { ButtonLink } from './components/link'
 import { Label } from './components/label'
 import { P, Lead } from './components/paragraph'
 
@@ -20,11 +21,6 @@ import { P, Lead } from './components/paragraph'
 const submitAndNavigate = (flagIdentifier, data) => {
   flagIdentifier({ variables: data })
   navigate('/summary')
-}
-
-const goBack = e => {
-  e.preventDefault()
-  window.location.href = '/'
 }
 
 const validate = values => {
@@ -90,9 +86,9 @@ const MyForm = () => (
                 </Container>
                 <Container display="flex" flexDirection="row" width={1}>
                   <Container width={1 / 2}>
-                    <Button onClick={goBack}>
+                    <ButtonLink onClick={e => e.preventDefault} to="/">
                       &lt; <Trans>Back</Trans>
-                    </Button>
+                    </ButtonLink>
                   </Container>
                   <Container width={1 / 2}>
                     <Button

--- a/frontend/src/Page2.js
+++ b/frontend/src/Page2.js
@@ -86,7 +86,7 @@ const MyForm = () => (
                 </Container>
                 <Container display="flex" flexDirection="row" width={1}>
                   <Container width={1 / 2}>
-                    <ButtonLink onClick={e => e.preventDefault} to="/">
+                    <ButtonLink to="/">
                       &lt; <Trans>Back</Trans>
                     </ButtonLink>
                   </Container>

--- a/frontend/src/Summary.js
+++ b/frontend/src/Summary.js
@@ -6,7 +6,7 @@ import { Container } from './components/container'
 import { Trans } from '@lingui/macro'
 import { H1, H2 } from './components/header'
 import { P } from './components/paragraph'
-import { Button } from './components/button'
+import { ButtonLink } from './components/link'
 
 export const Summary = () => (
   <Container mx={'auto'} width={[1, 1, 1]}>
@@ -29,14 +29,8 @@ export const Summary = () => (
     </P>
     <TrackPageViews />
 
-    <Button
-      mb={[3, null, 5]}
-      onClick={() => {
-        window.location.href = '/'
-      }}
-      value="Tell us another"
-    >
+    <ButtonLink mb={[3, null, 5]} to="/">
       <Trans>Submit another</Trans>
-    </Button>
+    </ButtonLink>
   </Container>
 )

--- a/frontend/src/components/link/index.js
+++ b/frontend/src/components/link/index.js
@@ -1,4 +1,5 @@
-import React from 'react'
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core'
 import { asAnchor } from '../../utils/asAnchor'
 import { Link as ReachLink } from '@reach/router'
 import PropTypes from 'prop-types'
@@ -20,6 +21,29 @@ export const Link = props => (
 )
 
 Link.propTypes = {
+  children: PropTypes.any,
+}
+
+export const ButtonLink = props => (
+  <BaseLink
+    fontSize={[2, null, 3]}
+    fontWeight="normal"
+    lineHeight={[2, null, 3]}
+    colors="button"
+    mt={[2, null, 3]}
+    py={1}
+    px={[2, null, 3]}
+    {...props}
+    css={css`
+      text-decoration: none;
+    `}
+    display="inline-block"
+  >
+    {props.children}
+  </BaseLink>
+)
+
+ButtonLink.propTypes = {
   children: PropTypes.any,
 }
 

--- a/frontend/src/utils/asAnchor.js
+++ b/frontend/src/utils/asAnchor.js
@@ -6,6 +6,7 @@ import {
   space,
   fontWeight,
   colorStyle,
+  display,
 } from 'styled-system'
 import cleanElement from 'clean-element'
 import PropTypes from 'prop-types'
@@ -25,6 +26,7 @@ export const asAnchor = AnchorType => {
     ...space.propTypes,
     ...colorStyle.propTypes,
     ...fontWeight.propTypes,
+    ...display.propTypes,
   }
 
   const StyledAnchor = styled(CleanAnchor)`
@@ -35,6 +37,7 @@ export const asAnchor = AnchorType => {
     ${space};
     ${colorStyle};
     ${fontWeight};
+    ${display};
   `
   return StyledAnchor
 }


### PR DESCRIPTION
This PR replaces the buttons with a button esque styled Reach Link component, to fix the language flow of the app. This PR is a "quick fix" for testing tomorrow, and would require some refactoring after (some props are showing up from styled-system that shouldn't, not using steve's component, etc)