### PR TITLE
Clean up cache creation

### DIFF
--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -21,11 +21,7 @@ const cache = new InMemoryCache()
 // Add defaults for form fields
 cache.writeData({
   data: {
-    language: 'en',
-    whatHappened: '',
-    whatWasInvolved: [],
-    whatWasInvolvedOther: '',
-    howWereYouAffected: '',
+    language: navigator.languages.includes('fr') ? 'fr' : 'en',
   },
 })
 

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -16,12 +16,18 @@ const typeDefs = gql`
   }
 `
 
-const cache = new InMemoryCache()
+const getLanguage = () => {
+  if (navigator.language.match(/^en/)) return 'en'
+  if (navigator.language.match(/^fr/)) return 'fr'
+  if (navigator.languages.filter(l => l.match(/^en/)).length > 0) return 'en'
+  if (navigator.languages.filter(l => l.match(/^fr/)).length > 0) return 'fr'
+}
 
+const cache = new InMemoryCache()
 // Add defaults for form fields
 cache.writeData({
   data: {
-    language: navigator.languages.includes('fr') ? 'fr' : 'en',
+    language: getLanguage(),
   },
 })
 

--- a/frontend/src/server.js
+++ b/frontend/src/server.js
@@ -50,10 +50,6 @@ server
     cache.writeData({
       data: {
         language: req.language,
-        whatHappened: '',
-        whatWasInvolved: [],
-        whatWasInvolvedOther: '',
-        howWereYouAffected: '',
       },
     })
 


### PR DESCRIPTION
The Apollo cache was being created with default values for the narrative
gathering tool. This commit removes those and defaults the cached value for
language to "fr" if it can find it in the navigator.languages array.