### PR TITLE
Serve better summary data

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1425,6 +1425,14 @@
         "cssom": "0.3.x"
       }
     },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1707,10 +1715,30 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.49",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
+      "integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "es6-promise": {
       "version": "4.2.5",
@@ -1723,6 +1751,15 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "escape-html": {
@@ -3185,6 +3222,11 @@
         "iterall": "^1.2.2"
       }
     },
+    "graphql-custom-types": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-custom-types/-/graphql-custom-types-1.5.0.tgz",
+      "integrity": "sha512-9hqP6dYACHuv47Ax/ob8kaa8R37pT+gvoRdlhXHZLs5u9/NSBp5CvL7yArSvhuR6HpeV7Sbbqh8tU8/NqV6LaQ=="
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -4615,6 +4657,11 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
+    "lodash.unionby": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lodash.unionby/-/lodash.unionby-4.8.0.tgz",
+      "integrity": "sha1-iD8Jj/ePVkpye3UI4JzdU5c0u4M="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4824,6 +4871,19 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "moment-range": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/moment-range/-/moment-range-4.0.2.tgz",
+      "integrity": "sha512-n8sceWwSTjmz++nFHzeNEUsYtDqjgXgcOBzsHi+BoXQU2FW+eU92LUaK8gqOiSu5PG57Q9sYj1Fz4LRDj4FtKA==",
+      "requires": {
+        "es6-symbol": "^3.1.0"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4885,6 +4945,11 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
       "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,11 @@
     "dotenv-safe": "^6.1.0",
     "express": "^4.16.4",
     "express-graphql": "^0.7.1",
-    "graphql": "^14.2.1"
+    "graphql": "^14.2.1",
+    "graphql-custom-types": "^1.5.0",
+    "lodash.unionby": "^4.8.0",
+    "moment": "^2.24.0",
+    "moment-range": "^4.0.2"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -3,32 +3,68 @@ type DailyTotal {
   total: Int
 }
 
+"""
+The DateTime scalar type represents date time strings complying to ISO-8601.
+"""
+scalar DateTime
+
 type identifierFlaggingsSummary {
   identifier: String
   summary: [DailyTotal]
 }
 
 type Mutation {
-  """Flag an identifier"""
+  """
+  Flag an identifier
+  """
   flagIdentifier(
-    """the suspects identifier (phone no, url or email)"""
+    """
+    the suspects identifier (phone no, url or email)
+    """
     identifier: String
   ): identifierFlaggingsSummary
 }
 
 type Query {
-  """Stats about report collection"""
+  """
+  Stats about report collection
+  """
   stats: Stats
 }
 
 type Stats {
-  """The total number of reports submitted."""
+  """
+  The total number of reports submitted.
+  """
   reportCount: Int
 
-  """Daily totals for the identifier specified"""
+  """
+  Daily totals for the identifier specified
+  """
   identifierFlaggingsWithin(
-    """the suspects identifier"""
+    """
+    the suspects identifier
+    """
     identifier: String
   ): identifierFlaggingsSummary
-}
 
+  """
+  Daily totals for the identifier specified
+  """
+  flaggingsWithin(
+    """
+    a phone number, email address or URL
+    """
+    identifier: String!
+
+    """
+    An ISO8601(YYYY-MM-DD) formatted date string
+    """
+    startDate: DateTime!
+
+    """
+    An ISO8601(YYYY-MM-DD) formatted date string
+    """
+    endDate: DateTime!
+  ): identifierFlaggingsSummary
+}

--- a/api/src/Stats.js
+++ b/api/src/Stats.js
@@ -1,4 +1,10 @@
-const { GraphQLString, GraphQLObjectType, GraphQLInt } = require('graphql')
+const {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLInt,
+} = require('graphql')
+const { GraphQLDateTime } = require('graphql-custom-types')
 const { FlaggingSummary } = require('./FlaggingSummary')
 
 const Stats = new GraphQLObjectType({
@@ -22,6 +28,35 @@ const Stats = new GraphQLObjectType({
       },
       resolve: async (_root, { identifier }, { db }) => {
         let summary = await db.summariseByDay(identifier)
+        return {
+          identifier,
+          summary,
+        }
+      },
+    },
+    flaggingsWithin: {
+      type: FlaggingSummary,
+      description: 'Daily totals for the identifier specified',
+      args: {
+        identifier: {
+          type: new GraphQLNonNull(GraphQLString),
+          description: 'a phone number, email address or URL',
+        },
+        startDate: {
+          type: new GraphQLNonNull(GraphQLDateTime),
+          description: 'An ISO8601(YYYY-MM-DD) formatted date string',
+        },
+        endDate: {
+          type: new GraphQLNonNull(GraphQLDateTime),
+          description: 'An ISO8601(YYYY-MM-DD) formatted date string',
+        },
+      },
+      resolve: async (_root, { identifier, startDate, endDate }, { db }) => {
+        let summary = await db.summariseReportsBetween({
+          startDate,
+          endDate,
+          identifier,
+        })
         return {
           identifier,
           summary,

--- a/api/src/__tests__/schema.test.js
+++ b/api/src/__tests__/schema.test.js
@@ -1,8 +1,73 @@
+const { graphql } = require('graphql')
+const { dbinit } = require('../dbinit')
 const { schema } = require('../schema')
+const { makeTestDatabase, dbNameFromFile } = require('../utils')
 
-describe('GraphQL Query Schema', () => {
-  it('Has a stats field', () => {
-    let Query = schema.getType('Query')
-    expect(Query.getFields()).toHaveProperty('stats')
+const { DB_USER: user, DB_URL: url, DB_PASSWORD: password } = process.env
+
+// eslint-disable-next-line
+let db, drop, truncate, reports, dbfunctions
+
+describe('Query Type', () => {
+  describe('Query.stats', () => {
+    it('exists', () => {
+      let Query = schema.getType('Query')
+      expect(Query.getFields()).toHaveProperty('stats')
+    })
+  })
+
+  describe('Query.stats.flaggingsWithin', () => {
+    beforeAll(async () => {
+      ;({ db, drop, truncate } = await makeTestDatabase({
+        dbname: dbNameFromFile(__filename),
+        user,
+        password,
+        url,
+        collections: ['reports'],
+      }))
+      reports = db.collection('reports')
+    })
+
+    it('returns a count per day of the flaggings for an identifier', async () => {
+      let variables = {
+        phone: '555-555-5555',
+        startDate: '2019-04-01',
+        endDate: '2019-04-02',
+      }
+      let query = `
+        query($phone: String!, $startDate: DateTime!, $endDate: DateTime!) {
+          stats {
+            flaggingsWithin(
+              identifier: $phone
+              startDate: $startDate
+              endDate: $endDate
+            ) {
+              identifier
+              summary {
+                date
+                total
+              }
+            }
+          }
+        }
+      `
+      let context = {
+        db: await dbinit(db),
+      }
+      let response = await graphql(schema, query, {}, context, variables)
+      expect(response).toEqual({
+        data: {
+          stats: {
+            flaggingsWithin: {
+              identifier: '555-555-5555',
+              summary: [
+                { date: '2019-04-01', total: 0 },
+                { date: '2019-04-02', total: 0 },
+              ],
+            },
+          },
+        },
+      })
+    })
   })
 })

--- a/api/src/__tests__/utils.test.js
+++ b/api/src/__tests__/utils.test.js
@@ -2,6 +2,7 @@ require('dotenv-safe').config()
 const {
   makeTestDatabase,
   dbNameFromFile,
+  generateDateObjects,
   getFilenameFromPath,
 } = require('../utils')
 
@@ -11,6 +12,32 @@ describe('Utils', () => {
   describe('getFilenameFromPath', () => {
     it('returns the filename given an absolute path', async () => {
       expect(getFilenameFromPath(__filename)).toEqual('utils.test.js')
+    })
+  })
+
+  describe('generateDateObjects', () => {
+    it('generates on object per day within a range', async () => {
+      let startDate = '2019-04-01'
+      let endDate = '2019-04-03'
+
+      let dates = generateDateObjects(startDate, endDate)
+      expect(dates).toEqual([
+        { date: '2019-04-01' },
+        { date: '2019-04-02' },
+        { date: '2019-04-03' },
+      ])
+    })
+
+    it('adds additional props if passed', async () => {
+      let startDate = '2019-04-01'
+      let endDate = '2019-04-03'
+
+      let dates = generateDateObjects(startDate, endDate, { foo: 'bar' })
+      expect(dates).toEqual([
+        { date: '2019-04-01', foo: 'bar' },
+        { date: '2019-04-02', foo: 'bar' },
+        { date: '2019-04-03', foo: 'bar' },
+      ])
     })
   })
 

--- a/api/src/dbinit.js
+++ b/api/src/dbinit.js
@@ -1,4 +1,10 @@
 const { aql } = require('arangojs')
+const {
+  generateDateObjects,
+  sortByDateAttribute,
+  uniqueArray,
+} = require('./utils')
+const unionBy = require('lodash.unionby')
 
 const dbinit = async db => {
   return {
@@ -16,6 +22,24 @@ const dbinit = async db => {
       `
       let results = await db.query(query)
       return results.next()
+    },
+    summariseReportsBetween: async ({ identifier, startDate, endDate }) => {
+      let query = aql`
+        FOR report IN reports
+          FILTER DATE_FORMAT(report.createdAt, "%yyyy-%mm-%dd") >= ${startDate} AND
+          DATE_FORMAT(report.createdAt, "%yyyy-%mm-%dd") <= ${endDate}
+          FILTER report.identifier == ${identifier}
+          COLLECT day = DATE_FORMAT(report.createdAt, "%yyyy-%mm-%dd")
+            WITH COUNT INTO count
+            RETURN {
+              date: day,
+              total: count
+            }
+      `
+      let results = await db.query(query)
+      let summaries = await results.all()
+      let dates = generateDateObjects(startDate, endDate, { total: 0 })
+      return sortByDateAttribute(uniqueArray(unionBy(summaries, dates, 'date')))
     },
     summariseByDay: async identifier => {
       let query = aql`

--- a/api/src/utils.js
+++ b/api/src/utils.js
@@ -1,9 +1,31 @@
 const { Database } = require('arangojs')
 const { parse } = require('path')
+const Moment = require('moment')
+const MomentRange = require('moment-range')
+const moment = MomentRange.extendMoment(Moment)
 
 const getFilenameFromPath = path => parse(path).base
 
 module.exports.getFilenameFromPath = getFilenameFromPath
+
+const generateDateObjects = (startDate, endDate, props = {}) => {
+  const start = moment(startDate)
+  const end = moment(endDate)
+  const range = moment.range(start, end)
+  const dates = Array.from(range.by('days'))
+  return dates.map(d =>
+    Object.assign({}, props, { date: d.format('YYYY-MM-DD') }),
+  )
+}
+
+module.exports.generateDateObjects = generateDateObjects
+
+const uniqueArray = a =>
+  [...new Set(a.map(o => JSON.stringify(o)))].map(s => JSON.parse(s))
+module.exports.uniqueArray = uniqueArray
+
+const sortByDateAttribute = a => a.sort((a, b) => a.date.localeCompare(b.date))
+module.exports.sortByDateAttribute = sortByDateAttribute
 
 const dbNameFromFile = filename =>
   getFilenameFromPath(filename).replace(/\./g, '_') + '_' + Date.now()


### PR DESCRIPTION
This commit adds a new function to the graphql api that returns proper data for
the summary graph. "Proper" in this case meaning that it the user supplies a
date range and the summary includes days with 0 reports within the range.

This addresses #255 and will be followed with a commit to get the frontend
using this new function.