### PR TITLE
Use better summary data

### DIFF
--- a/frontend/src/Chart.js
+++ b/frontend/src/Chart.js
@@ -1,0 +1,71 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { I18n } from '@lingui/react'
+import { t, Trans } from '@lingui/macro'
+import { H3 } from './components/header'
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ResponsiveContainer,
+} from 'recharts'
+import theme from './theme'
+
+export class Chart extends PureComponent {
+  render() {
+    return (
+      <I18n>
+        {({ i18n }) => (
+          <React.Fragment>
+            <H3 mt={6} textAlign="center">
+              <Trans>Reports similar to yours</Trans>
+            </H3>
+            <div style={{ width: '100%', height: 300 }}>
+              <ResponsiveContainer
+                width={this.props.width}
+                height={this.props.height}
+              >
+                <AreaChart
+                  data={this.props.data}
+                  margin={{
+                    top: 0,
+                    right: 0,
+                    left: -20,
+                    bottom: 0,
+                  }}
+                >
+                  <CartesianGrid strokeDasharray="2 2" />
+                  <XAxis fontFamily={theme.fontSans} dataKey="date" />
+                  <YAxis
+                    dataKey="total"
+                    fontFamily={theme.fontSans}
+                    label={{
+                      value: i18n._(t`Reports per day`),
+                      fontSize: '17px',
+                      angle: -90,
+                      fontFamily: theme.fontSans,
+                    }}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="total"
+                    stroke="#000"
+                    fill="#999"
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          </React.Fragment>
+        )}
+      </I18n>
+    )
+  }
+}
+
+Chart.propTypes = {
+  height: PropTypes.number,
+  width: PropTypes.number,
+  data: PropTypes.array,
+}

--- a/frontend/src/Stats.js
+++ b/frontend/src/Stats.js
@@ -1,75 +1,22 @@
-import React, { PureComponent } from 'react'
+import React from 'react'
 import { Query } from 'react-apollo'
 import PropTypes from 'prop-types'
-import { I18n } from '@lingui/react'
-import { t, Trans } from '@lingui/macro'
 import { P } from './components/paragraph'
-import { H3 } from './components/header'
-import { IDENTIFIER_FLAGGINGS_WITHIN } from './utils/queriesAndMutations'
-import {
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  ResponsiveContainer,
-} from 'recharts'
-import theme from './theme'
+import { FLAGGINGS_WITHIN } from './utils/queriesAndMutations'
 
-class Chart extends PureComponent {
-  render() {
-    return (
-      <I18n>
-        {({ i18n }) => (
-          <React.Fragment>
-            <H3 mt={6} textAlign="center">
-              <Trans>Reports similar to yours</Trans>
-            </H3>
-            <div style={{ width: '100%', height: 300 }}>
-              <ResponsiveContainer>
-                <AreaChart
-                  data={this.props.data}
-                  margin={{
-                    top: 0,
-                    right: 0,
-                    left: -20,
-                    bottom: 0,
-                  }}
-                >
-                  <CartesianGrid strokeDasharray="2 2" />
-                  <XAxis fontFamily={theme.fontSans} dataKey="date" />
-                  <YAxis
-                    dataKey="total"
-                    fontFamily={theme.fontSans}
-                    label={{
-                      value: i18n._(t`Reports per day`),
-                      fontSize: '17px',
-                      angle: -90,
-                      fontFamily: theme.fontSans,
-                    }}
-                  />
-                  <Area
-                    type="monotone"
-                    dataKey="total"
-                    stroke="#000"
-                    fill="#999"
-                  />
-                </AreaChart>
-              </ResponsiveContainer>
-            </div>
-          </React.Fragment>
-        )}
-      </I18n>
-    )
-  }
-}
-
-Chart.propTypes = { data: PropTypes.array }
-
-export const Stats = () => (
+export const Stats = ({
+  identifier = '555-555-5555',
+  startDate = '2019-04-01',
+  endDate = '2019-04-20',
+  children,
+}) => (
   <Query
-    query={IDENTIFIER_FLAGGINGS_WITHIN}
-    variables={{ identifier: '555-555-5555' }}
+    query={FLAGGINGS_WITHIN}
+    variables={{
+      identifier,
+      startDate,
+      endDate,
+    }}
     errorPolicy="all"
   >
     {({ loading, error, data }) => {
@@ -84,7 +31,16 @@ export const Stats = () => (
         )
 
       let { stats } = data
-      return <Chart data={stats.identifierFlaggingsWithin.summary} />
+      {
+        return children(stats.flaggingsWithin)
+      }
     }}
   </Query>
 )
+
+Stats.propTypes = {
+  identifier: PropTypes.string.isRequired,
+  startDate: PropTypes.string.isRequired,
+  endDate: PropTypes.string.isRequired,
+  children: PropTypes.func.isRequired,
+}

--- a/frontend/src/Summary.js
+++ b/frontend/src/Summary.js
@@ -1,5 +1,8 @@
 /** @jsx jsx */
+// eslint-disable-next-line no-unused-vars
+import React from 'react'
 import { Stats } from './Stats'
+import { Chart } from './Chart'
 import { TrackPageViews } from './TrackPageViews'
 import { jsx } from '@emotion/core'
 import { Container } from './components/container'
@@ -14,11 +17,20 @@ export const Summary = () => (
       <Trans>Thank you for reporting.</Trans>
     </H1>
 
-    <H2 fontSize={[3, null, 4]}>
-      <Trans>You‘re the 12th person to help us with this scam.</Trans>
-    </H2>
-
-    <Stats />
+    <Stats
+      identifier="555-555-5555"
+      startDate="2019-04-01"
+      endDate="2019-04-20"
+    >
+      {({ summary }) => (
+        <>
+          <H2 fontSize={[3, null, 4]}>
+            <Trans>You‘re the 12th person to help us with this scam.</Trans>
+          </H2>
+          <Chart data={summary} />
+        </>
+      )}
+    </Stats>
 
     <P>
       <Trans>

--- a/frontend/src/__tests__/Stats.test.js
+++ b/frontend/src/__tests__/Stats.test.js
@@ -1,31 +1,49 @@
 import React from 'react'
 import wait from 'waait'
-import { mount } from 'enzyme'
+import { render, cleanup } from 'react-testing-library'
 import { MockedProvider } from 'react-apollo/test-utils'
 import { I18nProvider } from '@lingui/react'
 import { Stats } from '../Stats'
+import { Chart } from '../Chart'
 import en from '../../locale/en/messages.js'
-import { IDENTIFIER_FLAGGINGS_WITHIN } from '../utils/queriesAndMutations'
+import { FLAGGINGS_WITHIN } from '../utils/queriesAndMutations'
 const catalogs = { en }
+
+let data = [
+  {
+    date: '2019-04-01',
+    total: 1,
+  },
+  {
+    date: '2019-04-02',
+    total: 1,
+  },
+  {
+    date: '2019-04-03',
+    total: 3,
+  },
+  {
+    date: '2019-04-04',
+    total: 0,
+  },
+]
 
 let mocks = [
   {
     request: {
-      query: IDENTIFIER_FLAGGINGS_WITHIN,
-      variables: { identifier: '555-555-5555' },
+      query: FLAGGINGS_WITHIN,
+      variables: {
+        identifier: '555-555-5555',
+        startDate: '2019-04-01',
+        endDate: '2019-04-04',
+      },
     },
     result: {
       data: {
         stats: {
-          identifierFlaggingsWithin: {
+          flaggingsWithin: {
             identifier: '555-555-5555',
-            summary: [
-              { date: 'Monday', total: 6 },
-              { date: 'Tuesday', total: 9 },
-              { date: 'Wednesday', total: 23 },
-              { date: 'Thursday', total: 30 },
-              { date: 'Friday', total: 54 },
-            ],
+            summary: data,
           },
         },
       },
@@ -34,21 +52,37 @@ let mocks = [
 ]
 
 describe('<Stats/>', () => {
+  afterEach(cleanup)
   describe('when the API returns data', () => {
-    it('displays stats', async () => {
+    it(`calls it's child as a function`, async () => {
       /* eslint-disable no-console */
       let warn = console.warn
       console.warn = jest.fn()
-      let wrapper = mount(
+      let { container } = render(
         <MockedProvider mocks={mocks} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
-            <Stats />
+            <Stats
+              identifier="555-555-5555"
+              startDate="2019-04-01"
+              endDate="2019-04-04"
+            >
+              {({ summary }) => (
+                <Chart height={100} width={100} data={summary} />
+              )}
+            </Stats>
           </I18nProvider>
         </MockedProvider>,
       )
 
+      // Wait for promise with data to resolve
       await wait(0)
-      expect(wrapper.text()).toMatch('')
+
+      let chartLabels = Array.from(container.querySelectorAll('tspan')).map(
+        e => e.innerHTML,
+      )
+
+      let dates = data.map(d => d.date)
+      expect(chartLabels).toContain(...dates)
       console.warn = warn
       /* eslint-enable no-console */
     })
@@ -56,43 +90,70 @@ describe('<Stats/>', () => {
 
   describe('when loading', () => {
     it('displays an empty string', async () => {
-      let wrapper = mount(
+      /* eslint-disable no-console */
+      let warn = console.warn
+      console.warn = jest.fn()
+      let { container } = render(
         <MockedProvider mocks={mocks} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
-            <Stats />
+            <Stats
+              identifier="555-555-5555"
+              startDate="2019-04-01"
+              endDate="2019-04-04"
+            >
+              {({ summary }) => (
+                <Chart height={100} width={100} data={summary} />
+              )}
+            </Stats>
           </I18nProvider>
         </MockedProvider>,
       )
 
-      expect(wrapper.text()).toMatch('')
+      let child = container.firstChild
+      expect(child.textContent).toEqual('')
+      console.warn = warn
+      /* eslint-enable no-console */
     })
   })
 
   describe('when an error is raised', () => {
-    it('displays an error message', async () => {
+    it('displays an error message instead of the child', async () => {
       /* eslint-disable no-console */
       let warn = console.warn
       console.warn = jest.fn()
-      let mocks = [
+      let failureMock = [
         {
           request: {
-            query: IDENTIFIER_FLAGGINGS_WITHIN,
-            variables: { identifier: '555-555-5555' },
+            query: FLAGGINGS_WITHIN,
+            variables: {
+              identifier: '555-555-5555',
+              startDate: '2019-04-01',
+              endDate: '2019-04-04',
+            },
           },
           error: new Error('sadness'),
         },
       ]
 
-      let wrapper = mount(
-        <MockedProvider mocks={mocks} addTypename={false}>
+      let { container } = render(
+        <MockedProvider mocks={failureMock} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
-            <Stats />
+            <Stats
+              identifier="555-555-5555"
+              startDate="2019-04-01"
+              endDate="2019-04-04"
+            >
+              {({ summary }) => (
+                <Chart height={100} width={100} data={summary} />
+              )}
+            </Stats>
           </I18nProvider>
         </MockedProvider>,
       )
 
       await wait(0)
-      expect(wrapper.text()).toMatch(/sadness/)
+      let child = container.firstChild
+      expect(child.textContent).toMatch(/sadness/)
       console.warn = warn
       /* eslint-enable no-console */
     })

--- a/frontend/src/utils/queriesAndMutations.js
+++ b/frontend/src/utils/queriesAndMutations.js
@@ -5,6 +5,23 @@ export const GET_LANGUAGE_QUERY = gql`
     language @client
   }
 `
+export const FLAGGINGS_WITHIN = gql`
+  query($identifier: String!, $startDate: DateTime!, $endDate: DateTime!) {
+    stats {
+      flaggingsWithin(
+        identifier: $identifier
+        startDate: $startDate
+        endDate: $endDate
+      ) {
+        identifier
+        summary {
+          date
+          total
+        }
+      }
+    }
+  }
+`
 
 export const IDENTIFIER_FLAGGINGS_WITHIN = gql`
   query($identifier: String!) {


### PR DESCRIPTION
This commit modifies the frontend to make use of the new flaggingsWithin
function exposed by the api. This will address some of the shortcomings with
the data visualization (ie, not displaying days with 0 reports).
The values for the demo are still hardcoded (ie the phone number identifier),
but the refactoring here will allow us to remove them and get this working for
real easily. This will be the focus of a followup PR.