### PR TITLE
Don't prettify api/schema.graphql

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,1 +1,2 @@
 manifests/
+../api/schema.graphql


### PR DESCRIPTION
Schema.graphql is meant to give a nice clean view of schema changes, as it gets
regenerated on each commit. Unfortunately since prettier reformats it every
time it's regenerated it ends up as noise in a lot of commits. Adding it to a
.prettierignore file will stop this.