### PR TITLE
Refactor cloudbuild file

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -16,29 +16,25 @@ steps:
     entrypoint: npm
     args: ['ci']
 
-  - name: node:11.10-alpine
+  - name: node:11-alpine
     dir: api
     entrypoint: npm
     args: ['test']
     env:
-      - 'DB_NAME=usesthis_test'
-      - 'DB_URL=http://arangodb:8529'
-      - 'DB_USER=root'
-      - 'DB_PASSWORD=test'
+      - 'DB_NAME=$_DB_NAME'
+      - 'DB_URL=$_DB_URL'
+      - 'DB_USER=$_DB_USER'
+      - 'DB_PASSWORD=$_DB_PASSWORD'
+      - 'MINIO_ACCESS_KEY=$_MINIO_ACCESS_KEY'
+      - 'MINIO_SECRET_KEY=$_MINIO_SECRET_KEY'
+      - 'MINIO_BUCKET_NAME=$_MINIO_BUCKET_NAME'
 
-  - name: 'gcr.io/cloud-builders/docker'
+  - name: gcr.io/kaniko-project/executor:debug
     dir: 'api'
     args:
-      [
-        'build',
-        '-t',
-        'gcr.io/$PROJECT_ID/api:$BRANCH_NAME-$SHORT_SHA',
-        '-t',
-        'gcr.io/$PROJECT_ID/api:latest',
-        '-f',
-        'Dockerfile',
-        '.',
-      ]
-images:
-  - 'gcr.io/$PROJECT_ID/api:$BRANCH_NAME-$SHORT_SHA'
-  - 'gcr.io/$PROJECT_ID/api:latest'
+      - '--destination=gcr.io/$PROJECT_ID/api:$BRANCH_NAME-$SHORT_SHA'
+      - '--destination=gcr.io/$PROJECT_ID/api:latest'
+      - '--dockerfile=./Dockerfile'
+      - '--reproducible'
+      - '--cache=true'
+      - '--cache-ttl=6h'


### PR DESCRIPTION
This commit reworks the cloudbuild file, moving test credentials and such into
variables and adding a few missing variables.

You may also note that we are now using kaniko for image building. This is a
new tools that lets you build containers without docker, and it should give a
bit of a speed boost as well as making our images reproducable (ie, two images
with the same content build at different times would have the same SHA).