### PR TITLE
Add TEST_DB_URL to cloudbuild

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -23,6 +23,7 @@ steps:
     env:
       - 'DB_NAME=$_DB_NAME'
       - 'DB_URL=$_DB_URL'
+      - 'TEST_DB_URL=$_TEST_DB_URL'
       - 'DB_USER=$_DB_USER'
       - 'DB_PASSWORD=$_DB_PASSWORD'
       - 'MINIO_ACCESS_KEY=$_MINIO_ACCESS_KEY'


### PR DESCRIPTION
This commit adds an important variable to the cloudbuild config that allows the
test step to communicate with the arangodb test database started in the first
step.
A value for the $_TEST_DB_URL variable has already been defined in the API trigger on Cloudbuild.