### PR TITLE
Add .flux file to control manifest generation

### DIFF
--- a/platform/.flux.yaml
+++ b/platform/.flux.yaml
@@ -1,0 +1,8 @@
+version: 1
+commandUpdated:
+  generators:
+    - command: kustomize build overlays/aks
+  updaters:
+    - containerImage:
+        command: >-
+          cd overlays/aks && kustomize edit set image "$FLUX_IMG:$FLUX_TAG"


### PR DESCRIPTION
This commit adds a config file for Flux to allow [manifest
generation](https://github.com/weaveworks/flux/blob/master/site/fluxyaml-config-files.md).

The idea here is that Flux runs within the cluster and generate config using
custom commands (kustomize!). This file controls the specifics of how that
works.