### PR TITLE
Disable husky githook install in CI

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -15,6 +15,7 @@ steps:
     dir: api
     entrypoint: npm
     args: ['ci']
+    env: ['HUSKY_SKIP_INSTALL=true']
 
   - name: node:11-alpine
     id: lint

--- a/frontend/cloudbuild.yaml
+++ b/frontend/cloudbuild.yaml
@@ -4,6 +4,7 @@ steps:
     dir: frontend
     entrypoint: npm
     args: ['ci']
+    env: ['HUSKY_SKIP_INSTALL=true']
 
   - name: node:11-alpine
     id: compile-languages


### PR DESCRIPTION
This commit adds an environmental variable to the cloudbuild config files that prevents [Husky](https://github.com/typicode/husky/blob/master/DOCS.md#disable-auto-install) from installing itself during the build process.