### PR TITLE
Remove size plugin

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8590,20 +8590,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "cds-size-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/cds-size-plugin/-/cds-size-plugin-1.3.0.tgz",
-      "integrity": "sha512-ev/1zVtQq/zDmmnV429dUlG/pQlHMCCYDp5hTCl9XmobtumRXwDNj0g+Nl6+rZA0jORhq+t3d96mHYVTqGp1zg==",
-      "requires": {
-        "chalk": "^2.4.2",
-        "escape-string-regexp": "^1.0.5",
-        "glob": "^7.1.3",
-        "gzip-size": "^5.0.0",
-        "minimatch": "^3.0.4",
-        "pretty-bytes": "^5.1.0",
-        "util.promisify": "^1.0.0"
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -20593,11 +20579,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
       "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
-    },
-    "pretty-bytes": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.1.0.tgz",
-      "integrity": "sha512-wa5+qGVg9Yt7PB6rYm3kXlKzgzgivYTLRandezh43jjRqgyDyP+9YxfJpJiLs9yKD1WeU8/OvtToWpW7255FtA=="
     },
     "pretty-format": {
       "version": "23.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
     "apollo-link-http": "^1.5.15",
     "apollo-upload-client": "^10.0.1",
     "babel-plugin-macros": "^2.6.1",
-    "cds-size-plugin": "^1.3.0",
     "emotion": "^10.0.14",
     "emotion-server": "^10.0.14",
     "emotion-theming": "^10.0.14",

--- a/frontend/razzle.config.js
+++ b/frontend/razzle.config.js
@@ -1,7 +1,5 @@
 module.exports = {
   modify: (config, { _target, _dev }, _webpack) => {
-    const SizePlugin = require('cds-size-plugin')
-    config.plugins.push(new SizePlugin())
     return config
   },
 }


### PR DESCRIPTION
Removing because the bundle size plugin frequently fails and blocks our builds.
Integration has been removed in Github as well.