### PR TITLE
Fix pages' maxWidth

### DIFF
--- a/frontend/src/components/container/index.js
+++ b/frontend/src/components/container/index.js
@@ -11,7 +11,9 @@ import {
   flexBasis,
   flexDirection,
   width,
+  maxWidth,
   height,
+  maxHeight,
   color,
   borders,
   borderColor,
@@ -41,7 +43,9 @@ export const Container = styled('div', {
   ${flexBasis}
   ${flexDirection}
   ${width}
+  ${maxWidth}
   ${height}
+  ${maxHeight}
   ${color}
   ${display}
   ${space}


### PR DESCRIPTION
fixes #509 

maxwidth working again

No idea why it ever worked? Container didn't have a `maxWidth` prop (unless it being included automagically by something in styled-system that changed). Odd.