### PR TITLE
stop linting dockerfiles

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,8 +1,0 @@
-workflow "Lint all Dockerfiles" {
-  on = "push"
-  resolves = ["Dockerfile linter"]
-}
-
-action "Dockerfile linter" {
-  uses = "docker://cdssnc/docker-lint"
-}


### PR DESCRIPTION
This was something that the platform team made, but it often crashes master for no reason. We can always add it back if it is fixed.