### PR TITLE
Allow blank dates (Fix for Issue #598)

### DIFF
--- a/frontend/src/p1/forms/ScamInfoForm.js
+++ b/frontend/src/p1/forms/ScamInfoForm.js
@@ -53,7 +53,12 @@ export class ScamInfoForm extends Component {
 
   localOnSubmit = (client, data) => {
     const { onSubmit } = this.props
-    data.whenWereYouContacted = this.startDate.toISOString().slice(0, 10)
+
+    if (this.startDate != null && this.startDate.length > 0) {
+      data.whenWereYouContacted = this.startDate.toISOString().slice(0, 10)
+    } else {
+      data.whenWereYouContacted = ''
+    }
     onSubmit(client, data)
   }
 

--- a/frontend/src/p2/forms/TimeFrameInfoForm.js
+++ b/frontend/src/p2/forms/TimeFrameInfoForm.js
@@ -38,8 +38,18 @@ class TimeFrameInfoFormWrapped extends Component {
 
   localOnSubmit = (client, data) => {
     const { onSubmit } = this.props
-    data.startDate = this.startDate.toISOString()
-    data.endDate = this.endDate.toISOString()
+    if (this.startDate != null && this.startDate.length > 0) {
+      data.startDate = this.startDate.toISOString()
+    } else {
+      data.startDate = ''
+    }
+
+    if (this.endDate != null && this.endDate.length > 0) {
+      data.endDate = this.endDate.toISOString()
+    } else {
+      data.endDate = ''
+    }
+
     onSubmit(client, data)
   }
 


### PR DESCRIPTION
This is a fix for allowing blank dates (Issue #598) in the Timeframe page (P2) and the Narrative Page (P1).

Fixed this by adding a check for null and length before parsing the string into a date.

You can test this by running the deployment, removing/erase/clear the date and then clicking continue.