### PR TITLE
Get baseline app running in k8s

### DIFF
--- a/platform/base/baseline-deployment.yaml
+++ b/platform/base/baseline-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: cybercrime-api
+  labels:
+    app: baseline
+  name: baseline
+  annotations:
+    flux.weave.works/automated: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: baseline
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: baseline
+    spec:
+      containers:
+      - image: gcr.io/report-a-cybercrime-alpha/baseline
+        name: baseline
+        resources: {}
+        env:
+          - name: DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: cybercrime-api-secrets
+                key: DB_USER
+          - name: DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: cybercrime-api-secrets
+                key: DB_NAME
+          - name: DB_URL
+            valueFrom:
+              secretKeyRef:
+                name: cybercrime-api-secrets
+                key: DB_URL
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: cybercrime-api-secrets
+                key: DB_PASSWORD
+status: {}

--- a/platform/base/baseline-ingress.yaml
+++ b/platform/base/baseline-ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  namespace: cybercrime-api
+  name: baseline-ingress
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    ingress.kubernetes.io/content-type-nosniff: "true"
+    ingress.kubernetes.io/browser-xss-filter: "true"
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: baseline
+              servicePort: 3000
+            path: /CAFCFRS
+    - http:
+        paths:
+          - backend:
+              serviceName: baseline
+              servicePort: 3000
+            path: /wet-boew
+    - http:
+        paths:
+          - backend:
+              serviceName: baseline
+              servicePort: 3000
+            path: /assets

--- a/platform/base/baseline-service.yaml
+++ b/platform/base/baseline-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: cybercrime-api
+  creationTimestamp: null
+  labels:
+    app: baseline
+  name: baseline
+spec:
+  ports:
+  - name: "3000"
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: baseline
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/platform/base/kustomization.yaml
+++ b/platform/base/kustomization.yaml
@@ -19,6 +19,9 @@ resources:
 - cybercrime-frontend-ingress.yaml
 - cybercrime-frontend-namespace.yaml
 - cybercrime-frontend-service.yaml
+- baseline-deployment.yaml
+- baseline-ingress.yaml
+- baseline-service.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:


### PR DESCRIPTION
This commit adds the kubernetes configuration to run the baseline app. It is
available at `/CAFCFRS` due to expectations of the code.