### PR TITLE
register pageview using GA pageview method

### DIFF
--- a/frontend/src/TrackPageViews.js
+++ b/frontend/src/TrackPageViews.js
@@ -12,7 +12,7 @@ ReactGA.set({ anonymizeIp: true })
 
 const logPageView = path => {
   if (typeof window === 'object') {
-    ReactGA.ga('send', 'event', 'pageview', path)
+    ReactGA.pageview(path)
   }
 }
 


### PR DESCRIPTION
fixes #677 
This seems to be the way to tell GA about pageviews (see https://github.com/react-ga/react-ga#reactgapageviewpath). running locally with the GA id, the realtime data was registering the pageviews as pageviews.