### PR TITLE
remove tell us more box

### DIFF
--- a/frontend/src/p2/ConfirmationPage.js
+++ b/frontend/src/p2/ConfirmationPage.js
@@ -10,7 +10,6 @@ import {
   getTimeFrame,
   getWhatHappened,
   getScammerDetails,
-  getTellUsMore,
   getImpact,
   getP2ContactInfo,
 } from '../utils/queriesAndMutations'
@@ -38,7 +37,6 @@ const submit = (client, submitReportP2) => {
   let scammerDetails = getScammerDetails(client)
   let impact = getImpact(client)
   let p2ContactInfo = getP2ContactInfo(client)
-  let tellUsMore = getTellUsMore(client)
 
   let { fullName, email, phone, postalCode } = p2ContactInfo
   fullName = randomizeString(fullName)
@@ -58,7 +56,6 @@ const submit = (client, submitReportP2) => {
       phone,
       postalCode,
     },
-    tellUsMore,
   }
   submitReportP2({ variables: data }) // currently fails, need new mutation
   navigate('nextsteps')

--- a/frontend/src/p2/forms/ConfirmationForm.js
+++ b/frontend/src/p2/forms/ConfirmationForm.js
@@ -1,39 +1,18 @@
 /** @jsx jsx */
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React from 'react'
 import { jsx } from '@emotion/core'
 import { ApolloConsumer, Mutation } from 'react-apollo'
-import { Trans } from '@lingui/macro'
-import { Form, Field } from 'react-final-form'
+import { Form } from 'react-final-form'
 import { ButtonsContainer } from '../../components/buttons-container'
-import { TextArea } from '../../components/text-area'
-import { Text } from '../../components/text'
-import { finalFormAdapter } from '../../utils/finalFormAdapter'
 import {
   getTellUsMore,
   SUBMIT_P2_REPORT_MUTATION,
 } from '../../utils/queriesAndMutations'
 
-const TextAreaAdapter = finalFormAdapter(TextArea)
-
 export const ConfirmationForm = props => {
-  const [tellUsMore, setTellUsMore] = useState('')
-
-  const onChange = (e, client) => {
-    setTellUsMore(e.target.value)
-    client.writeData({
-      data: { tellUsMore: JSON.stringify({ tellUsMore: e.target.value }) },
-    })
-  }
-
   return (
     <React.Fragment>
-      <hr />
-      <Text marginTop={[5, null, 6]}>
-        <Trans>
-          <strong>Tell us more</strong>
-        </Trans>
-      </Text>
       <ApolloConsumer>
         {client => (
           <Mutation mutation={SUBMIT_P2_REPORT_MUTATION}>
@@ -43,29 +22,6 @@ export const ConfirmationForm = props => {
                 onSubmit={() => props.onSubmit(client, submitReportP2)}
                 render={({ handleSubmit }) => (
                   <form onSubmit={handleSubmit}>
-                    <label htmlFor="tellUsMore">
-                      <Text fontSize={(1, null, 2)}>
-                        <Trans>
-                          Is there any information you'd like to add that didn't
-                          fit elsewhere?
-                        </Trans>
-                      </Text>
-                    </label>
-                    <div>
-                      <Field
-                        input={{
-                          value: tellUsMore
-                            ? tellUsMore
-                            : getTellUsMore(client).tellUsMore,
-                          onChange: e => onChange(e, client),
-                        }}
-                        name="tellUsMore"
-                        id="tellUsMore"
-                        component={TextAreaAdapter}
-                        height="75px"
-                      />
-                    </div>
-
                     <ButtonsContainer
                       buttonLink={false}
                       cancel={true}

--- a/frontend/src/utils/queriesAndMutations.js
+++ b/frontend/src/utils/queriesAndMutations.js
@@ -309,7 +309,6 @@ export const SUBMIT_P2_REPORT_MUTATION = gql`
     $impact: impact!
     $scammerDetails: scammerDetails!
     $contactInfo: P2ContactInfoInput!
-    $tellUsMore: tellUsMore!
   ) {
     submitReportP2(
       source: $source
@@ -318,7 +317,6 @@ export const SUBMIT_P2_REPORT_MUTATION = gql`
       impact: $impact
       scammerDetails: $scammerDetails
       contactInfo: $contactInfo
-      tellUsMore: $tellUsMore
     ) {
       reportID
     }


### PR DESCRIPTION
resolves #650 

remove "Tell Us More" box from confirmation page of prototype 2.

Currently it's just hacked out. If we really don't want any new inputs on the confirmation page, we can simplify the code by eliminating the `ConfirmationForm.js` file, moving the buttons from it to `ConfirmationPage.js`.