### PR TITLE
Add liveness/readiness checks to cybercrime-api

### DIFF
--- a/api/src/__tests__/server.test.js
+++ b/api/src/__tests__/server.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest')
+const { Server } = require('../server')
+
+describe('Server', () => {
+  describe('/alive', () => {
+    it('returns 200 indicating the process is alive', async () => {
+      const app = await Server({
+        db: jest.fn(),
+      })
+      const response = await request(app).get('/alive')
+
+      expect(response.status).toEqual(200)
+    })
+  })
+
+  describe('/ready', () => {
+    it('returns 200 after verifying it can connect to ArangoDB', async () => {
+      // Simulate Arangojs database.version()
+      // https://bit.ly/2kqEhpc
+      const context = {
+        db: {
+          version: () =>
+            Promise.resolve({
+              server: 'arango',
+              license: 'community',
+              version: '3.5.0',
+            }),
+        },
+      }
+      const app = await Server(context)
+      const response = await request(app).get('/ready')
+
+      expect(response.status).toEqual(200)
+    })
+
+    it('returns 500 if it cannot connect to ArangoDB', async () => {
+      // Simulate Arangojs database.version()
+      // https://bit.ly/2kqEhpc
+      const context = {
+        db: {
+          version: () => Promise.reject({}), // eslint-disable-line
+        },
+      }
+      const app = await Server(context)
+      const response = await request(app).get('/ready')
+
+      expect(response.status).toEqual(500)
+    })
+  })
+})

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -7,6 +7,23 @@ const cors = require('cors')
 const Server = async context => {
   const app = express()
 
+  app.get('/alive', (_req, res) => {
+    res.send('yes')
+  })
+
+  app.get('/ready', async (_req, res) => {
+    try {
+      const version = await context.db.version()
+      if (version) {
+        res.send('yes')
+      } else {
+        res.status(500).json({ error: 'Unable to connect to ArangoDB' })
+      }
+    } catch (error) {
+      res.status(500).json({ error: error.toString() })
+    }
+  })
+
   app.use(
     '/',
     cors(),
@@ -31,6 +48,7 @@ const Server = async context => {
       context,
     }),
   )
+
   return app
 }
 

--- a/platform/base/cybercrime-api-deployment.yaml
+++ b/platform/base/cybercrime-api-deployment.yaml
@@ -10,15 +10,15 @@ metadata:
     flux.weave.works/tag.cybercrime-api: glob:master-*
   name: cybercrime-api
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: cybercrime-api
   strategy:
     rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
+      maxSurge: 1
+      maxUnavailable: 50%
     type: RollingUpdate
   template:
     metadata:
@@ -54,6 +54,14 @@ spec:
         - image: gcr.io/report-a-cybercrime-alpha/api
           imagePullPolicy: Always
           name: cybercrime-api
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: 3000
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3000
           env:
             - name: DB_USER
               valueFrom:


### PR DESCRIPTION
These checks allow Kubernetes to confim that the service is alive and ready to
handle traffic. Together with the values in `.spec.strategy.rollingUpdate` these
checks allow Kubernetes to replace existing pods only when new versions are
running and functional.