### PR TITLE
Replace getByText and getByLabelText

### DIFF
--- a/frontend/src/p1/forms/__tests__/ContactInfoForm.test.js
+++ b/frontend/src/p1/forms/__tests__/ContactInfoForm.test.js
@@ -29,7 +29,7 @@ describe('<ContactInfoForm />', () => {
   it.only('calls the onSubmit function when the form is submitted', async () => {
     const submitMock = jest.fn()
 
-    const { getByLabelText, getByText } = render(
+    const { getAllByRole, getByRole } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={[]} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
@@ -41,8 +41,8 @@ describe('<ContactInfoForm />', () => {
       </ThemeProvider>,
     )
 
-    const inputNode = getByLabelText('Full name')
-    const nextButton = getByText(/Next/i)
+    const inputNode = getAllByRole('textbox')[0] // just the first
+    const nextButton = getByRole('button')
 
     fillIn(inputNode, { with: 'Mallory' })
     clickOn(nextButton)

--- a/frontend/src/p1/forms/__tests__/MoneyLostForm.test.js
+++ b/frontend/src/p1/forms/__tests__/MoneyLostForm.test.js
@@ -29,7 +29,7 @@ describe('<MoneyLostForm /> form', () => {
   it('calls the onSubmit function when the form is submitted', async () => {
     const submitMock = jest.fn()
 
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByRole } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={[]} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
@@ -42,7 +42,7 @@ describe('<MoneyLostForm /> form', () => {
     )
 
     const inputNode = getByLabelText('Amount of money')
-    const nextButton = getByText(/Next/i)
+    const nextButton = getByRole('button')
 
     fillIn(inputNode, { with: '$10,000' })
     clickOn(nextButton)

--- a/frontend/src/p1/forms/__tests__/ScamInfoForm.test.js
+++ b/frontend/src/p1/forms/__tests__/ScamInfoForm.test.js
@@ -29,7 +29,7 @@ describe('<ScamInfoForm />', () => {
   it('calls the onSubmit function when the form is submitted', async () => {
     const submitMock = jest.fn()
 
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByRole } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={[]} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
@@ -42,7 +42,7 @@ describe('<ScamInfoForm />', () => {
     )
 
     const inputNode = getByLabelText('When did it start?')
-    const nextButton = getByText(/Next/i)
+    const nextButton = getByRole('button')
 
     fillIn(inputNode, { with: 'in person' })
     clickOn(nextButton)

--- a/frontend/src/p1/forms/__tests__/SuspectInfoForm.test.js
+++ b/frontend/src/p1/forms/__tests__/SuspectInfoForm.test.js
@@ -28,7 +28,7 @@ describe('<SuspectInfoForm />', () => {
   it('calls the onSubmit function when the form is submitted', async () => {
     const submitMock = jest.fn()
 
-    const { getByLabelText, getByText } = render(
+    const { getAllByRole, getByRole } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={[]} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
@@ -40,8 +40,8 @@ describe('<SuspectInfoForm />', () => {
       </ThemeProvider>,
     )
 
-    const inputNode = getByLabelText('Name')
-    const nextButton = getByText(/Next/i)
+    const inputNode = getAllByRole('textbox')[0]
+    const nextButton = getByRole('button')
 
     fillIn(inputNode, { with: 'Malory' })
     clickOn(nextButton)

--- a/frontend/src/p2/forms/__tests__/ContactInfoForm.test.js
+++ b/frontend/src/p2/forms/__tests__/ContactInfoForm.test.js
@@ -29,7 +29,7 @@ describe('<ContactInfoForm />', () => {
   it.only('calls the onSubmit function when the form is submitted', async () => {
     const submitMock = jest.fn()
 
-    const { getByLabelText, getByText } = render(
+    const { getAllByRole, getByRole } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={[]} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
@@ -41,8 +41,8 @@ describe('<ContactInfoForm />', () => {
       </ThemeProvider>,
     )
 
-    const inputNode = getByLabelText('Full name')
-    const nextButton = getByText(/Next/i)
+    const inputNode = getAllByRole('textbox')[0]
+    const nextButton = getByRole('button')
 
     fillIn(inputNode, { with: 'Mallory' })
     clickOn(nextButton)

--- a/frontend/src/p2/forms/__tests__/ImpactStatementInfoForm.test.js
+++ b/frontend/src/p2/forms/__tests__/ImpactStatementInfoForm.test.js
@@ -29,7 +29,7 @@ describe('<ImpactStatementInfoForm />', () => {
   it('calls the onSubmit function when the form is submitted', async () => {
     const submitMock = jest.fn()
 
-    const { getByText } = render(
+    const { getByRole } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={[]} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
@@ -41,7 +41,7 @@ describe('<ImpactStatementInfoForm />', () => {
       </ThemeProvider>,
     )
 
-    const nextButton = getByText(/Next/i)
+    const nextButton = getByRole('button')
 
     clickOn(nextButton)
     await wait(0) // Wait for promises to resolve

--- a/frontend/src/p2/forms/__tests__/ScammerDetailsForm.test.js
+++ b/frontend/src/p2/forms/__tests__/ScammerDetailsForm.test.js
@@ -26,7 +26,7 @@ describe('<ScammerDetailsForm />', () => {
   it('calls the onSubmit function when the form is submitted', async () => {
     const submitMock = jest.fn()
 
-    const { getByText } = render(
+    const { getByRole } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={[]} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
@@ -37,7 +37,7 @@ describe('<ScammerDetailsForm />', () => {
         </MockedProvider>
       </ThemeProvider>,
     )
-    const nextButton = getByText(/Next/i)
+    const nextButton = getByRole('button')
 
     clickOn(nextButton)
     await wait(0) // Wait for promises to resolve

--- a/frontend/src/p2/forms/__tests__/TimeFrameInfoForm.test.js
+++ b/frontend/src/p2/forms/__tests__/TimeFrameInfoForm.test.js
@@ -26,7 +26,7 @@ describe('<TimeFrameInfoForm />', () => {
   it('calls the onSubmit function when the form is submitted', async () => {
     const submitMock = jest.fn()
 
-    const { getByText } = render(
+    const { getByRole } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={[]} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
@@ -38,7 +38,7 @@ describe('<TimeFrameInfoForm />', () => {
       </ThemeProvider>,
     )
 
-    const nextButton = getByText(/Next/i)
+    const nextButton = getByRole('button')
     clickOn(nextButton)
     await wait(0) // Wait for promises to resolve
 

--- a/frontend/src/p2/forms/__tests__/WhatHappenedForm.test.js
+++ b/frontend/src/p2/forms/__tests__/WhatHappenedForm.test.js
@@ -26,7 +26,7 @@ describe('<WhatHappenedForm />', () => {
   it('calls the onSubmit function when the form is submitted', async () => {
     const submitMock = jest.fn()
 
-    const { getByText } = render(
+    const { getByRole } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={[]} addTypename={false}>
           <I18nProvider language={'en'} catalogs={catalogs}>
@@ -39,7 +39,7 @@ describe('<WhatHappenedForm />', () => {
     )
 
     // find the next button so we can trigger a form submission
-    const nextButton = getByText(/Next/i)
+    const nextButton = getByRole('button')
     // Click the next button to trigger the form submission
     clickOn(nextButton)
     await wait(0) // Wait for promises to resolve


### PR DESCRIPTION
These functions made it difficult to evolve the content without test breakage.
This commit removes almost all usage of these functions. The remaining cases
are either in p1 (soon to be deleted), the components folder (not effected by
content changes), or are cases where the text being searched for is supplied in
the actual test.