### PR TITLE
don't say black triangle in link

### DIFF
--- a/frontend/src/components/backbutton/index.js
+++ b/frontend/src/components/backbutton/index.js
@@ -28,7 +28,8 @@ export const BackButton = ({ route = '', children }) => (
   >
     <Link type="button" to={route} textAlign="left">
       <Trans>
-        <span>&#9664;</span> <span>Back to</span> <span>{children}</span>
+        <span aria-label=" ">&#9664;</span> <span>Back to</span>{' '}
+        <span>{children}</span>
       </Trans>
     </Link>
   </div>


### PR DESCRIPTION
fixed #813 

stop screen readers from pronouncing "black triangle" in the back links.

Note that I had to set the `aria-label` to a space, setting it to an empty string caused voiceover to again say "black triangle"