### PR TITLE
use a darker blue

### DIFF
--- a/frontend/src/theme/index.js
+++ b/frontend/src/theme/index.js
@@ -28,7 +28,7 @@ export const BREAKPOINTS = ['320px', '641px', '769px']
 const colors = {
   white: '#FFF',
   black: '#000',
-  blue: '#005ea5',
+  blue: '#003a66',
   lightBlue: '#2b8cc4',
   purple: '#4c2c92',
   yellow: '#ffbf47',


### PR DESCRIPTION
fixes #814 

Darken up the blue we use a bit so links meet WCAG AAA.

old:

![image](https://user-images.githubusercontent.com/8228248/67317994-ded31700-f4d8-11e9-8094-4a86fb5e26c0.png)

new:

![image](https://user-images.githubusercontent.com/8228248/67317948-cf53ce00-f4d8-11e9-8fb4-94d033376140.png)
