### PR TITLE
Stick footer to bottom of screen in f2

### DIFF
--- a/f2/src/App.js
+++ b/f2/src/App.js
@@ -15,7 +15,7 @@ import { Content } from './components/container'
 const App = () => {
   const { i18n } = useLingui()
   return (
-    <main>
+    <React.Fragment>
       <Global
         styles={css`
           html,
@@ -76,7 +76,7 @@ const App = () => {
           </FooterLink>
         </Footer>
       </ThemeProvider>
-    </main>
+    </React.Fragment>
   )
 }
 


### PR DESCRIPTION
resolves #922

We had two `<main>` blocks in `f2` (one inside the other). Removing the outer one fixed this, and is more semantically correct.