### PR TITLE
make text fields are described once instead of twice for blind

### DIFF
--- a/f2/src/forms/WhatHappenedForm.js
+++ b/f2/src/forms/WhatHappenedForm.js
@@ -38,7 +38,7 @@ export const WhatHappenedForm = props => (
                     </Text>
                   </FormHelperText>
                   <TextArea
-                    id="whatHappened"
+                    id="whatHappened:textarea"
                     name={props.input.name}
                     value={props.input.value}
                     onChange={props.input.onChange}


### PR DESCRIPTION
 make text fields are described once instead of twice for blind participant by using screen-readers.