### PR TITLE
removed superfluous text from what happened form

### DIFF
--- a/f2/src/forms/WhatHappenedForm.js
+++ b/f2/src/forms/WhatHappenedForm.js
@@ -42,9 +42,6 @@ export const WhatHappenedForm = props => {
               </FormControl>
             )}
           </Field>
-          <P>
-            <Trans id="whatHappendPage.nextStep" />
-          </P>
           <NextAndCancelButtons>
             <Trans id="whatHappenedPage.nextButton" />
           </NextAndCancelButtons>


### PR DESCRIPTION
# Description

![an image showing the otext `whatHappendPage.nextStep` on a form with a blue outline added](https://people.debian.org/~taowa/ReportACrime-NextStep.png)

- [ x ] Bug fix
