### PR TITLE
dont clear data on thankyou page

### DIFF
--- a/f2/src/ConfirmationPage.js
+++ b/f2/src/ConfirmationPage.js
@@ -67,7 +67,7 @@ const submitToServer = async data => {
 }
 
 export const ConfirmationPage = () => {
-  const [{ formData }, dispatch] = useStateValue()
+  const [{ formData }, dispatch] = useStateValue() // eslint-disable-line no-unused-vars
 
   return (
     <Route
@@ -89,7 +89,7 @@ export const ConfirmationPage = () => {
               onSubmit={() => {
                 let data = prepFormData(formData)
                 submitToServer(data)
-                dispatch({ type: 'deleteFormData', data: {} })
+                // dispatch({ type: 'deleteFormData', data: {} })  restore after testing
                 history.push('/thankYouPage')
               }}
             />

--- a/f2/src/ConfirmationSummary.js
+++ b/f2/src/ConfirmationSummary.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { Trans } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import { Link } from './components/link'
-import { Stack, Code } from '@chakra-ui/core'
+import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 
 import { HowDidItStartSummary } from './summary/HowDidItStartSummary'
@@ -92,7 +92,6 @@ export const ConfirmationSummary = () => {
   return (
     <React.Fragment>
       <Stack spacing={12} shouldWrapChildren>
-        <Code>{JSON.stringify(data)}</Code>
         <HowDidItStartSummary />
         <WhatWasAffectedSummary />
         <MoneyLostInfoSummary />


### PR DESCRIPTION
# Description

stop clearing the data on the thankyou page, This means in testing we can go back to the confirmation page and discuss the answers with the user.


- [x] New feature

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made any needed changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Required followup work

might have to restore it later