### PR TITLE
more spacing on how did it start page

### DIFF
--- a/f2/src/forms/HowDidItStartForm.js
+++ b/f2/src/forms/HowDidItStartForm.js
@@ -163,15 +163,15 @@ export const HowDidItStartForm = props => {
             as="form"
             onSubmit={handleSubmit}
             shouldWrapChildren
-            spacing={6}
+            spacing={12}
           >
             <Control as="fieldset" name="howDidTheyReachYou">
               <FormLabel as="legend" htmlFor="howDidTheyReachYou" mb={2}>
                 <Trans id="howDidTheyReachYou.question" />
               </FormLabel>
               <FormHelperText>
-                    <Trans id="howDidTheyReachYou.reminder" />
-                  </FormHelperText>
+                <Trans id="howDidTheyReachYou.reminder" />
+              </FormHelperText>
               <Stack spacing={4} shouldWrapChildren>
                 {questionsList.map(question => {
                   return (


### PR DESCRIPTION
# Description

Adds a little spacing between questions on `howdiditstart`

- [x] UI fix

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made any needed changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Required followup work

figure out why the spacing seemed too tight only on this page. Set a standard across the app. Set a global spacing variable for formControls
