### PR TITLE
rough in CAFC readiness code

### DIFF
--- a/f2/server.js
+++ b/f2/server.js
@@ -68,12 +68,28 @@ const uploadData = (req, res) => {
   }
 }
 
+let count = 0
+
 app
   .use(express.static(path.join(__dirname, 'build')))
   .use(bodyParser.json())
 
   .get('/ping', function(_req, res) {
     return res.send('pong')
+  })
+
+  .get('/available', function(_req, res) {
+    count += 1
+    switch (count % 3) {
+      case 1:
+        res.json({ acceptingReports: true })
+        break
+      case 2:
+        res.json({ acceptingReports: false })
+        break
+      default:
+        res.status(404).send('Not found')
+    }
   })
 
   .post('/submit', (req, res) => {


### PR DESCRIPTION
# Description

change the server to add a route to tell CAFC if we're accepting reports or not. Currently just a prototype that alternates between accepting, not accepting, and 404. This is to allow CAFC to test the code they're building.

To test: locally run `node server.js` (instead of `npm run dev`) and go to `localhost:3000/available` 

Fixes #1201 

- [x] New feature

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made any needed changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Required followup work

Still need to figure out and write the real logic for determining if we want another report.