### PR TITLE
Mark edit button text

### DIFF
--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -17,7 +17,7 @@
   "button.cancelReport": "Cancel report",
   "button.edit": "Edit",
   "confirmationPage.ImpactTitle": "What could be affected?",
-  "confirmationPage.ImpactTitle.edit":"Edit What Was Affected",
+  "confirmationPage.ImpactTitle.edit": "Edit What Was Affected",
   "confirmationPage.backButton": "Back to Your contact details",
   "confirmationPage.businessInfo.business": "Description",
   "confirmationPage.businessInfo.title": "Business",

--- a/f2/src/summary/BusinessInfoSummary.js
+++ b/f2/src/summary/BusinessInfoSummary.js
@@ -9,7 +9,6 @@ import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
 
 export const BusinessInfoSummary = props => {
-
   const [data] = useStateValue()
 
   const businessInfo = {
@@ -23,6 +22,7 @@ export const BusinessInfoSummary = props => {
         <div>
           {/*: mark the proper ids for lingui */}
           <Trans id="confirmationPage.businessInfo.business" />
+          <Trans id="confirmationPage.businessInfo.title.edit" />
         </div>
       ) : null}
 
@@ -32,7 +32,10 @@ export const BusinessInfoSummary = props => {
             <Trans id="confirmationPage.businessInfo.title" />
           </H2>
 
-          <EditButton path="/business" label="confirmationPage.businessInfo.title.edit" />
+          <EditButton
+            path="/business"
+            label="confirmationPage.businessInfo.title.edit"
+          />
         </Flex>
 
         <Stack as="dl" spacing={4}>

--- a/f2/src/summary/ContactInfoSummary.js
+++ b/f2/src/summary/ContactInfoSummary.js
@@ -26,6 +26,7 @@ export const ContactInfoSummary = ({ onSubmit }) => {
           {/*: mark the proper ids for lingui */}
           <Trans id="confirmationPage.contactInfo.email" />
           <Trans id="confirmationPage.contactInfo.phone" />
+          <Trans id="confirmationPage.contactTitle.edit" />
         </div>
       ) : null}
 
@@ -34,7 +35,10 @@ export const ContactInfoSummary = ({ onSubmit }) => {
           <H2>
             <Trans id="confirmationPage.contactTitle" />
           </H2>
-          <EditButton path="/contactinfo" label="confirmationPage.contactTitle.edit" />
+          <EditButton
+            path="/contactinfo"
+            label="confirmationPage.contactTitle.edit"
+          />
         </Flex>
         {hasInfoToDisplay ? (
           <Stack as="dl" spacing={4}>

--- a/f2/src/summary/DevicesSummary.js
+++ b/f2/src/summary/DevicesSummary.js
@@ -23,6 +23,7 @@ export const DevicesSummary = props => {
           {/*: mark the proper ids for lingui */}
           <Trans id="confirmationPage.devices.deviceOrAccount" />
           <Trans id="confirmationPage.devices.devicesTellUsMore" />
+          <Trans id="confirmationPage.devicesTitle.edit" />
         </div>
       ) : null}
 

--- a/f2/src/summary/EvidenceInfoSummary.js
+++ b/f2/src/summary/EvidenceInfoSummary.js
@@ -1,4 +1,5 @@
 /** @jsx jsx */
+import React from 'react'
 import { jsx } from '@emotion/core'
 import { Trans } from '@lingui/macro'
 import { Stack, Flex, Box } from '@chakra-ui/core'
@@ -18,36 +19,48 @@ export const EvidenceInfoSummary = props => {
   }
 
   return (
-    <Stack spacing={4} borderBottom="2px" borderColor="gray.300" pb={4}>
-      <Flex align="baseline">
-        <H2>
-          <Trans id="confirmationPage.evidence.title" />
-        </H2>
-        <EditButton path="/evidence" label="confirmationPage.evidence.title.edit" />
-      </Flex>
-      {evidence.files.length > 0 || evidence.fileDescriptions.length > 0 ? (
-        <Stack as="dl" spacing={4} shouldWrapChildren>
-          {evidence.files ? (
-            <Stack as="dl" spacing={4} shouldWrapChildren>
-              {evidence.files.map((file, index) => (
-                <Flex key={index} pb={4}>
-                  <Text pr={4}>{index + 1}.</Text>
-                  <Box>
-                    <Text as="dt" fontWeight="bold">
-                      {file}
-                    </Text>
-                    <Text as="dd">{evidence.fileDescriptions[index]}</Text>
-                  </Box>
-                </Flex>
-              ))}
-            </Stack>
-          ) : null}
-        </Stack>
-      ) : (
-        <Text>
-          <Trans id="confirmationPage.evidence.nag" />
-        </Text>
-      )}
-    </Stack>
+    <React.Fragment>
+      {false ? (
+        <div>
+          {/*: mark the proper ids for lingui */}
+          <Trans id="confirmationPage.evidence.title.edit" />
+        </div>
+      ) : null}
+
+      <Stack spacing={4} borderBottom="2px" borderColor="gray.300" pb={4}>
+        <Flex align="baseline">
+          <H2>
+            <Trans id="confirmationPage.evidence.title" />
+          </H2>
+          <EditButton
+            path="/evidence"
+            label="confirmationPage.evidence.title.edit"
+          />
+        </Flex>
+        {evidence.files.length > 0 || evidence.fileDescriptions.length > 0 ? (
+          <Stack as="dl" spacing={4} shouldWrapChildren>
+            {evidence.files ? (
+              <Stack as="dl" spacing={4} shouldWrapChildren>
+                {evidence.files.map((file, index) => (
+                  <Flex key={index} pb={4}>
+                    <Text pr={4}>{index + 1}.</Text>
+                    <Box>
+                      <Text as="dt" fontWeight="bold">
+                        {file}
+                      </Text>
+                      <Text as="dd">{evidence.fileDescriptions[index]}</Text>
+                    </Box>
+                  </Flex>
+                ))}
+              </Stack>
+            ) : null}
+          </Stack>
+        ) : (
+          <Text>
+            <Trans id="confirmationPage.evidence.nag" />
+          </Text>
+        )}
+      </Stack>
+    </React.Fragment>
   )
 }

--- a/f2/src/summary/HowDidItStartSummary.js
+++ b/f2/src/summary/HowDidItStartSummary.js
@@ -51,6 +51,7 @@ export const HowDidItStartSummary = ({ onSubmit }) => {
           <Trans id="confirmationPage.howDidItStart.others" />
           <Trans id="confirmationPage.whenDidItStart" />
           <Trans id="confirmationPage.howManyTimes" />
+          <Trans id="confirmationPage.howDidItStart.title.edit" />
         </div>
       ) : null}
 
@@ -59,7 +60,10 @@ export const HowDidItStartSummary = ({ onSubmit }) => {
           <H2>
             <Trans id="confirmationPage.howDidItStart.title" />
           </H2>
-          <EditButton path="/howdiditstart" label="confirmationPage.howDidItStart.title.edit" />
+          <EditButton
+            path="/howdiditstart"
+            label="confirmationPage.howDidItStart.title.edit"
+          />
         </Flex>
 
         {hasDataToDisplay ? (

--- a/f2/src/summary/InformationSummary.js
+++ b/f2/src/summary/InformationSummary.js
@@ -24,6 +24,7 @@ export const InformationSummary = props => {
           <Trans id="confirmationPage.personalInformation.typeOfInfoReq" />
           <Trans id="confirmationPage.personalInformation.typeOfInfoObtained" />
           <Trans id="confirmationPage.personalInformation.tellUsMore" />
+          <Trans id="confirmationPage.personalInformation.title.edit" />
         </div>
       ) : null}
 

--- a/f2/src/summary/LocationInfoSummary.js
+++ b/f2/src/summary/LocationInfoSummary.js
@@ -26,6 +26,7 @@ export const LocationInfoSummary = ({ onSubmit }) => {
           {/*: mark the proper ids for lingui */}
           <Trans id="confirmationPage.location.postalCode" />
           <Trans id="confirmationPage.location.cityTown" />
+          <Trans id="confirmationPage.location.title.edit" />
         </div>
       ) : null}
 
@@ -34,7 +35,10 @@ export const LocationInfoSummary = ({ onSubmit }) => {
           <H2>
             <Trans id="confirmationPage.location.title" />
           </H2>
-          <EditButton path="/location" label="confirmationPage.location.title.edit" />
+          <EditButton
+            path="/location"
+            label="confirmationPage.location.title.edit"
+          />
         </Flex>
         {hasInfoToDisplay ? (
           <Stack as="dl" spacing={4}>

--- a/f2/src/summary/MoneyLostInfoSummary.js
+++ b/f2/src/summary/MoneyLostInfoSummary.js
@@ -26,6 +26,7 @@ export const MoneyLostInfoSummary = props => {
           <Trans id="confirmationPage.moneyLost.methodPayment" />
           <Trans id="confirmationPage.moneyLost.transactionDate" />
           <Trans id="confirmationPage.moneyLost.tellUsMore" />
+          <Trans id="confirmationPage.moneyLostTitle.edit" />
         </div>
       ) : null}
       <Stack spacing={4} borderBottom="2px" borderColor="gray.300" pb={4}>
@@ -33,7 +34,10 @@ export const MoneyLostInfoSummary = props => {
           <H2>
             <Trans id="confirmationPage.moneyLostTitle" />
           </H2>
-          <EditButton path="/moneylost" label="confirmationPage.moneyLostTitle.edit" />
+          <EditButton
+            path="/moneylost"
+            label="confirmationPage.moneyLostTitle.edit"
+          />
         </Flex>
 
         <Stack as="dl" spacing={4}>

--- a/f2/src/summary/SuspectCluesSummary.js
+++ b/f2/src/summary/SuspectCluesSummary.js
@@ -29,6 +29,7 @@ export const SuspectCluesSummary = () => {
           <Trans id="confirmationPage.suspectClues.suspectClues1" />
           <Trans id="confirmationPage.suspectClues.suspectClues2" />
           <Trans id="confirmationPage.suspectClues.suspectClues3" />
+          <Trans id="confirmationPage.suspectClues.title.edit" />
         </div>
       ) : null}
 
@@ -37,7 +38,10 @@ export const SuspectCluesSummary = () => {
           <H2>
             <Trans id="confirmationPage.suspectClues.title" />
           </H2>
-          <EditButton path="/suspectclues" label="confirmationPage.suspectClues.title.edit" />
+          <EditButton
+            path="/suspectclues"
+            label="confirmationPage.suspectClues.title.edit"
+          />
         </Flex>
         {hasInfoToDisplay ? (
           <Stack as="dl" spacing={4}>

--- a/f2/src/summary/WhatHappenedSummary.js
+++ b/f2/src/summary/WhatHappenedSummary.js
@@ -1,4 +1,5 @@
 /** @jsx jsx */
+import React from 'react'
 import { jsx } from '@emotion/core'
 import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
@@ -17,21 +18,33 @@ export const WhatHappenedSummary = props => {
   }
 
   return (
-    <Stack spacing={4} borderBottom="2px" borderColor="gray.300" pb={4}>
-      <Flex align="baseline">
-        <H2>
-          <Trans id="confirmationPage.whatHappened.title" />
-        </H2>
-        <EditButton label="confirmationPage.whatHappened.title.edit" path="/whathappened" />
-      </Flex>
+    <React.Fragment>
+      {false ? (
+        <div>
+          {/*: mark the proper ids for lingui */}
+          <Trans id="confirmationPage.whatHappened.title.edit" />
+        </div>
+      ) : null}
 
-      {whatHappened.whatHappened.length > 0 ? (
-        <Text>{whatHappened.whatHappened}</Text>
-      ) : (
-        <Text>
-          <Trans id="confirmationPage.whatHappened.nag" />
-        </Text>
-      )}
-    </Stack>
+      <Stack spacing={4} borderBottom="2px" borderColor="gray.300" pb={4}>
+        <Flex align="baseline">
+          <H2>
+            <Trans id="confirmationPage.whatHappened.title" />
+          </H2>
+          <EditButton
+            label="confirmationPage.whatHappened.title.edit"
+            path="/whathappened"
+          />
+        </Flex>
+
+        {whatHappened.whatHappened.length > 0 ? (
+          <Text>{whatHappened.whatHappened}</Text>
+        ) : (
+          <Text>
+            <Trans id="confirmationPage.whatHappened.nag" />
+          </Text>
+        )}
+      </Stack>
+    </React.Fragment>
   )
 }

--- a/f2/src/summary/WhatWasAffectedSummary.js
+++ b/f2/src/summary/WhatWasAffectedSummary.js
@@ -1,4 +1,5 @@
 /** @jsx jsx */
+import React from 'react'
 import { jsx } from '@emotion/core'
 import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
@@ -21,31 +22,42 @@ export const WhatWasAffectedSummary = props => {
   }
 
   return (
-    <Stack spacing={4} borderBottom="2px" borderColor="gray.300" pb={4}>
-      <Flex align="baseline">
-        <H2>
-          <Trans id="confirmationPage.ImpactTitle" />
-        </H2>
-        <EditButton path="/whatwasaffected" label="confirmationPage.ImpactTitle.edit" />
-      </Flex>
-      {impact.affectedOptions.length > 0 ? (
-        <Stack as="dl" spacing={4}>
-          <Text>
-            <Trans id="confirmationPage.whatWasAffected.format" />
-            &nbsp;
-            <Text as="span" textTransform="lowercase">
-              {intl.formatList(
-                impact.affectedOptions.map(i => i18n._(i)),
-                { type: 'conjunction' },
-              )}
+    <React.Fragment>
+      {false ? (
+        <div>
+          {/*: mark the proper ids for lingui */}
+          <Trans id="confirmationPage.ImpactTitle.edit" />
+        </div>
+      ) : null}
+      <Stack spacing={4} borderBottom="2px" borderColor="gray.300" pb={4}>
+        <Flex align="baseline">
+          <H2>
+            <Trans id="confirmationPage.ImpactTitle" />
+          </H2>
+          <EditButton
+            path="/whatwasaffected"
+            label="confirmationPage.ImpactTitle.edit"
+          />
+        </Flex>
+        {impact.affectedOptions.length > 0 ? (
+          <Stack as="dl" spacing={4}>
+            <Text>
+              <Trans id="confirmationPage.whatWasAffected.format" />
+              &nbsp;
+              <Text as="span" textTransform="lowercase">
+                {intl.formatList(
+                  impact.affectedOptions.map(i => i18n._(i)),
+                  { type: 'conjunction' },
+                )}
+              </Text>
             </Text>
+          </Stack>
+        ) : (
+          <Text>
+            <Trans id="confirmationPage.impactIntro" />
           </Text>
-        </Stack>
-      ) : (
-        <Text>
-          <Trans id="confirmationPage.impactIntro" />
-        </Text>
-      )}
-    </Stack>
+        )}
+      </Stack>
+    </React.Fragment>
   )
 }

--- a/f2/src/summary/__tests__/MoneyLostSummary.test.js
+++ b/f2/src/summary/__tests__/MoneyLostSummary.test.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { i18n } from '@lingui/core'
+import { render, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from 'emotion-theming'
+import { I18nProvider } from '@lingui/react'
+import { IntlProvider } from 'react-intl'
+import canada from '../../theme/canada'
+import en from '../../locales/en.json'
+import { StateProvider, initialState, reducer } from '../../utils/state'
+import { MoneyLostInfoSummary } from '../MoneyLostInfoSummary'
+
+i18n.load('en', { en })
+i18n.activate('en')
+
+describe('<MoneyLostInfoSummary />', () => {
+  afterEach(cleanup)
+
+  it('renders', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <IntlProvider locale={i18n.locale}>
+          <ThemeProvider theme={canada}>
+            <StateProvider initialState={initialState} reducer={reducer}>
+              <I18nProvider i18n={i18n}>
+                <MoneyLostInfoSummary />
+              </I18nProvider>
+            </StateProvider>
+          </ThemeProvider>
+        </IntlProvider>
+      </MemoryRouter>,
+    )
+  })
+})

--- a/f2/src/summary/__tests__/WhatWasAffectedSummary.test.js
+++ b/f2/src/summary/__tests__/WhatWasAffectedSummary.test.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { i18n } from '@lingui/core'
+import { render, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from 'emotion-theming'
+import { I18nProvider } from '@lingui/react'
+import { IntlProvider } from 'react-intl'
+import canada from '../../theme/canada'
+import en from '../../locales/en.json'
+import { StateProvider, initialState, reducer } from '../../utils/state'
+import { WhatWasAffectedSummary } from '../WhatWasAffectedSummary'
+
+i18n.load('en', { en })
+i18n.activate('en')
+
+describe('<WhatWasAffectedSummary />', () => {
+  afterEach(cleanup)
+
+  it('renders', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <IntlProvider locale={i18n.locale}>
+          <ThemeProvider theme={canada}>
+            <StateProvider initialState={initialState} reducer={reducer}>
+              <I18nProvider i18n={i18n}>
+                <WhatWasAffectedSummary />
+              </I18nProvider>
+            </StateProvider>
+          </ThemeProvider>
+        </IntlProvider>
+      </MemoryRouter>,
+    )
+  })
+})


### PR DESCRIPTION
# Description

As referenced in #1198 the text for the aria-labels wasn't marked for `npm run extract` to pick up. This fixes that.

Also adds 2 missing tests.

- [x] Bug fix

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made any needed changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Required followup work

none, other than making sure in-flight PRs don't incorrectly delete these lines.