### PR TITLE
added as prop to main container

### DIFF
--- a/f2/src/App.js
+++ b/f2/src/App.js
@@ -44,6 +44,7 @@ const App = () => {
             </header>
 
             <Flex
+              as="main"
               id="main"
               fontFamily="body"
               flex="1 0 auto"


### PR DESCRIPTION
Fixes #1254 

# Description

Fixes an a11y issue where we had no main landmark region

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code

# Required followup work

There are still the app version number that needs to be between the footer and the main. Maybe consider choosing one of the two regions or making up a custom region
