### PR TITLE
Remove conditional 'Other' input field on what could be affected page

### DIFF
--- a/f2/src/forms/WhatWasAffectedForm.js
+++ b/f2/src/forms/WhatWasAffectedForm.js
@@ -8,10 +8,6 @@ import { FormControl, Stack, Alert, AlertIcon } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { CheckboxAdapter } from '../components/checkbox'
 import { FormArrayControl } from '../components/FormArrayControl'
-import { Field } from '../components/Field'
-import { FormLabel } from '../components/FormLabel'
-import { ConditionalForm } from '../components/container'
-import { TextInput } from '../components/TextInput'
 
 const Control = ({ name, ...rest }) => {
   const {
@@ -92,26 +88,6 @@ export const WhatWasAffectedForm = props => {
                       >
                         {i18n._(key)}
                       </CheckboxAdapter>
-                      {key === 'whatWasAffectedForm.other' &&
-                        values.affectedOptions.includes(
-                          'whatWasAffectedForm.other',
-                        ) && (
-                          <ConditionalForm>
-                            <Field name="optionOther">
-                              {props => (
-                                <FormControl>
-                                  <FormLabel htmlFor={key}></FormLabel>
-                                  <TextInput
-                                    id="optionOther"
-                                    name={props.input.name}
-                                    value={props.input.value}
-                                    onChange={props.input.onChange}
-                                  />
-                                </FormControl>
-                              )}
-                            </Field>
-                          </ConditionalForm>
-                        )}
                     </React.Fragment>
                   )
                 })}

--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -85,7 +85,7 @@
   "confirmationPage.whatHappened.nag": "No information provided.",
   "confirmationPage.whatHappened.title": "What happened?",
   "confirmationPage.whatHappened.title.edit": "Edit What happened?",
-  "confirmationPage.whatWasAffected.format": "This affected my",
+  "confirmationPage.whatWasAffected.format": "This affected:",
   "confirmationPage.whenDidItStart": "Start date",
   "contactinfoPage.backButton": "Go back",
   "contactinfoPage.emailAddress": "Email address",

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -85,7 +85,7 @@
   "confirmationPage.whatHappened.nag": "Aucune information fournie.",
   "confirmationPage.whatHappened.title": "Que s'est-il passé?",
   "confirmationPage.whatHappened.title.edit": "Modifier Que s'est-il passé?",
-  "confirmationPage.whatWasAffected.format": "L'incident a affecté",
+  "confirmationPage.whatWasAffected.format": "L'incident a affecté :",
   "confirmationPage.whenDidItStart": "Début",
   "contactinfoPage.backButton": "Retour",
   "contactinfoPage.emailAddress": "Adresse courriel",


### PR DESCRIPTION
# Description

Removing conditional 'Other' input field on 'What could be affected' page

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens) 
- [x] I have added a comment to any confusing code