### PR TITLE
format date better

### DIFF
--- a/f2/src/summary/HowDidItStartSummary.js
+++ b/f2/src/summary/HowDidItStartSummary.js
@@ -6,6 +6,7 @@ import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
+import { formatDate } from '../utils/formatDate'
 import { testdata, EditButton } from '../ConfirmationSummary'
 import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
@@ -103,13 +104,11 @@ export const HowDidItStartSummary = props => {
               />
               <DescriptionListItem
                 descriptionTitle="confirmationPage.whenDidItStart"
-                description={
-                  howdiditstart.startDay +
-                  ' ' +
-                  howdiditstart.startMonth +
-                  ' ' +
-                  howdiditstart.startYear
-                }
+                description={formatDate(
+                  howdiditstart.startDay,
+                  howdiditstart.startMonth,
+                  howdiditstart.startYear,
+                )}
               />
               <DescriptionListItem
                 descriptionTitle="confirmationPage.howManyTimes"

--- a/f2/src/summary/MoneyLostInfoSummary.js
+++ b/f2/src/summary/MoneyLostInfoSummary.js
@@ -5,6 +5,7 @@ import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
+import { formatDate } from '../utils/formatDate'
 import { testdata, EditButton } from '../ConfirmationSummary'
 import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
@@ -81,13 +82,11 @@ export const MoneyLostInfoSummary = props => {
             />
             <DescriptionListItem
               descriptionTitle="confirmationPage.moneyLost.transactionDate"
-              description={
-                moneyLost.transactionDay +
-                ' ' +
-                moneyLost.transactionMonth +
-                ' ' +
-                moneyLost.transactionYear
-              }
+              description={formatDate(
+                moneyLost.transactionDay,
+                moneyLost.transactionMonth,
+                moneyLost.transactionYear,
+              )}
             />
             <DescriptionListItem
               descriptionTitle="confirmationPage.moneyLost.tellUsMore"

--- a/f2/src/utils/__tests__/formatDate.test.js
+++ b/f2/src/utils/__tests__/formatDate.test.js
@@ -1,0 +1,22 @@
+import { formatDate } from '../formatDate'
+
+describe('formatDate', () => {
+  it('formats a full date correctly', () => {
+    expect(formatDate(20, 1, 2020)).toEqual('20/1/2020')
+  })
+
+  it('formats a month/year correctly', () => {
+    expect(formatDate('', 1, 2020)).toEqual('1/2020')
+    expect(formatDate(undefined, 1, 2020)).toEqual('1/2020')
+  })
+
+  it('formats a year correctly', () => {
+    expect(formatDate('', '', 2020)).toEqual('2020')
+    expect(formatDate(undefined, undefined, 2020)).toEqual('2020')
+  })
+
+  it('formats empty data correctly', () => {
+    expect(formatDate('', '', '')).toEqual('')
+    expect(formatDate(undefined, undefined, undefined)).toEqual('')
+  })
+})

--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -1,5 +1,7 @@
 // 'use strict'
 
+const { formatDate } = require('./formatDate')
+
 const formatLine = (label, text) => (text !== '' ? label + text + '\n' : '')
 
 const formatReportInfo = data => {
@@ -44,7 +46,11 @@ const formatVictimDetails = data => {
 }
 
 const formatIncidentInformation = data => {
-  const occurenceString = `${data.howdiditstart.startDay}-${data.howdiditstart.startMonth}-${data.howdiditstart.startYear}`
+  const occurenceString = formatDate(
+    data.howdiditstart.startDay,
+    data.howdiditstart.startMonth,
+    data.howdiditstart.startYear,
+  )
   const freqString = data.howdiditstart.howManyTimes.replace(
     'howManyTimes.',
     '',
@@ -155,7 +161,11 @@ const formatFinancialTransactions = data => {
   const paymentString = data.moneyLost.methodPayment
     .map(method => method.replace('methodPayment.', ''))
     .join(', ')
-  const transactionDate = `${data.moneyLost.transactionDay}-${data.moneyLost.transactionMonth}-${data.moneyLost.transactionYear}`
+  const transactionDate = formatDate(
+    data.moneyLost.transactionDay,
+    data.moneyLost.transactionMonth,
+    data.moneyLost.transactionYear,
+  )
   const returnString =
     formatLine('Money requested:     ', data.moneyLost.demandedMoney) +
     formatLine('Money lost:          ', data.moneyLost.moneyTaken) +

--- a/f2/src/utils/formatDate.js
+++ b/f2/src/utils/formatDate.js
@@ -1,0 +1,2 @@
+export const formatDate = (day, month, year) =>
+  `${day}/${month}/${year}`.replace(/undefined/g, '').replace(/^\/+/, '')

--- a/f2/src/utils/formatDate.js
+++ b/f2/src/utils/formatDate.js
@@ -1,2 +1,7 @@
-export const formatDate = (day, month, year) =>
-  `${day}/${month}/${year}`.replace(/undefined/g, '').replace(/^\/+/, '')
+module.exports = {
+  formatDate(day, month, year) {
+    return `${day}/${month}/${year}`
+      .replace(/undefined/g, '')
+      .replace(/^\/+/, '')
+  },
+}


### PR DESCRIPTION
Fixes #1489 
Fixes #1486 

# Description

Write a `formatDate(day, month, year)` function and use in the summary pages. Format empty inputs to an empty string, and omits leading slashes (ie if there's no day then just give month/year)

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
