### PR TITLE
fix for skipping location

### DIFF
--- a/f2/src/forms/LocationInfoForm.js
+++ b/f2/src/forms/LocationInfoForm.js
@@ -14,11 +14,22 @@ import { Flex, Icon } from '@chakra-ui/core'
 import { P } from '../components/paragraph'
 import { Button } from '../components/button'
 
+const defaultLocation = {
+  postalCode: '',
+}
+
 export const LocationInfoForm = props => {
-  const [data] = useStateValue()
-  const location = {
-    postalCode: '',
-    ...data.formData.location,
+  const [data, dispatch] = useStateValue()
+
+  let location
+  if (!data.formData.location) {
+    dispatch({ type: 'saveFormData', data: { location: defaultLocation } })
+    location = defaultLocation
+  } else {
+    location = {
+      ...defaultLocation,
+      ...data.formData.location,
+    }
   }
 
   return (


### PR DESCRIPTION
Fixes #1513 

# Description

Save location as `{postalCode: ''}` even if skipped.

# Checklist:

- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
