### PR TITLE
add app info-best viewed with Chrome or Firefox  on landing page

### DIFF
--- a/f2/src/LandingPage.js
+++ b/f2/src/LandingPage.js
@@ -31,6 +31,13 @@ export const LandingPage = props => {
             <Stack spacing={10} shouldWrapChildren>
               <H1>
                 <Trans id="landingPage.title" />
+
+                <Stack spacing={3}>
+                <Alert status="info">
+               <AlertIcon />
+             <Trans id="landingpage.appinfo"/>
+             </Alert>
+             </Stack>
               </H1>
               <Stack spacing={4}>
                 <P>

--- a/f2/src/LandingPage.js
+++ b/f2/src/LandingPage.js
@@ -29,15 +29,12 @@ export const LandingPage = props => {
         <Page>
           <Layout columns={{ base: 4 / 4, md: 6 / 8, lg: 7 / 12 }}>
             <Stack spacing={10} shouldWrapChildren>
-              <H1>
-                <Trans id="landingPage.title" />
 
-                <Stack spacing={3}>
-                <Alert status="info">
-               <AlertIcon />
-             <Trans id="landingpage.appinfo"/>
-             </Alert>
-             </Stack>
+              <Alert status="success" backgroundColor="blue.100">
+                <AlertIcon name="info-outline" color="blue.800" />
+                <Trans id="landingpage.appinfo" />
+              </Alert> <H1>
+                <Trans id="landingPage.title" />
               </H1>
               <Stack spacing={4}>
                 <P>
@@ -60,7 +57,6 @@ export const LandingPage = props => {
                     />
                   </Trans>
                 </P>
-
                 <Row>
                   <LandingBox>
                     <H2>
@@ -118,11 +114,7 @@ export const LandingPage = props => {
                   </LandingBox>
                 </Row>
 
-                <Alert status="success" backgroundColor="blue.100">
-                  <AlertIcon name="info-outline" color="blue.800" />
-                  <Trans id="landingPage.warning" />
-                </Alert>
-
+                <P><Trans id="landingPage.warning" /></P>
                 <H2>
                   <Trans id="landingPage.reportingOptions" />
                 </H2>
@@ -173,7 +165,7 @@ export const LandingPage = props => {
               </Stack>
             </Stack>
           </Layout>
-        </Page>
+        </Page >
       )}
     />
   )

--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -204,6 +204,7 @@
   "landingPage.reportingOptions3": "If you encountered the incident online, you can also try reporting it to the website or app where it happened.",
   "landingPage.title": "Report a scam or computer crime",
   "landingPage.warning": "Reporting does not always lead to an investigation and we likely won’t be able to recover what was lost or damaged.",
+  "landingpage.appinfo": "This app is best viewed with Firefox or Chrome",
   "locationPage.backButton": "Go back",
   "locationPage.intro": "We use your location to link your report to other reports in your area and to coordinate with local police services across Canada.",
   "locationPage.title": "Enter your location",

--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -204,7 +204,7 @@
   "landingPage.reportingOptions3": "If you encountered the incident online, you can also try reporting it to the website or app where it happened.",
   "landingPage.title": "Report a scam or computer crime",
   "landingPage.warning": "Reporting does not always lead to an investigation and we likely won’t be able to recover what was lost or damaged.",
-  "landingpage.appinfo": "This app is best viewed with Firefox or Chrome",
+  "landingpage.appinfo": "This website is best viewed on Firefox or Google Chrome.",
   "locationPage.backButton": "Go back",
   "locationPage.intro": "We use your location to link your report to other reports in your area and to coordinate with local police services across Canada.",
   "locationPage.title": "Enter your location",

--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -204,7 +204,7 @@
   "landingPage.reportingOptions3": "If you encountered the incident online, you can also try reporting it to the website or app where it happened.",
   "landingPage.title": "Report a scam or computer crime",
   "landingPage.warning": "Reporting does not always lead to an investigation and we likely won’t be able to recover what was lost or damaged.",
-  "landingpage.appinfo": "This website is best viewed on Firefox or Google Chrome.",
+  "landingpage.appinfo": "This website is best viewed on Firefox or Google Chrome web browsers.",
   "locationPage.backButton": "Go back",
   "locationPage.intro": "We use your location to link your report to other reports in your area and to coordinate with local police services across Canada.",
   "locationPage.title": "Enter your location",

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -204,7 +204,7 @@
   "landingPage.reportingOptions3": "Si l’incident s’est produit en ligne, vous pouvez le signaler sur le site Web ou sur l’application où il a eu lieu.",
   "landingPage.title": "Signalez une fraude ou un crime informatique",
   "landingPage.warning": "Les signalements ne mènent pas toujours à une enquête. Il est peu probable que nous puissions récupérer ce qui a été perdu ou endommagé.",
-  "landingpage.appinfo": "Cette application est optimisée pour Firefox ou Chrome",
+  "landingpage.appinfo": "Ce site Web est optimisé pour les navigateurs Firefox et Google Chrome.",
   "locationPage.backButton": "Retour",
   "locationPage.intro": "Nous utilisons votre emplacement géographique pour établir un lien entre votre rapport et les autres rapports de votre région, et pour collaborer avec les services de police locaux partout au Canada.",
   "locationPage.title": "Votre emplacement géographique",

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -204,6 +204,7 @@
   "landingPage.reportingOptions3": "Si l’incident s’est produit en ligne, vous pouvez le signaler sur le site Web ou sur l’application où il a eu lieu.",
   "landingPage.title": "Signalez une fraude ou un crime informatique",
   "landingPage.warning": "Les signalements ne mènent pas toujours à une enquête. Il est peu probable que nous puissions récupérer ce qui a été perdu ou endommagé.",
+  "landingpage.appinfo": "Cette application est optimisée pour Firefox ou Chrome",
   "locationPage.backButton": "Retour",
   "locationPage.intro": "Nous utilisons votre emplacement géographique pour établir un lien entre votre rapport et les autres rapports de votre région, et pour collaborer avec les services de police locaux partout au Canada.",
   "locationPage.title": "Votre emplacement géographique",


### PR DESCRIPTION
Fixes #1538(issue)

# Description
add app info alert on landing page " this app is best viewed with Chrome or Firefox"

# Checklist:

- [x ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)

