### PR TITLE
use extension in file paths

### DIFF
--- a/f2/src/utils/__tests__/getData.test.js
+++ b/f2/src/utils/__tests__/getData.test.js
@@ -1,0 +1,13 @@
+import { getFileExtension } from '../getData'
+
+describe('getFileExtension', () => {
+  it('finds an extension', () => {
+    expect(getFileExtension('test.JPG')).toEqual('jpg')
+  })
+
+  it('is empty if there is no extension', () => {
+    expect(getFileExtension('')).toEqual('')
+    expect(getFileExtension('test')).toEqual('')
+    expect(getFileExtension('.JPG')).toEqual('')
+  })
+})

--- a/f2/src/utils/getData.js
+++ b/f2/src/utils/getData.js
@@ -5,6 +5,14 @@ const crypto = require('crypto')
 const { selfHarmWordsScan } = require('./selfHarmWordsScan')
 const { generateReportId } = require('./generateReportId')
 
+const getFileExtension = filename => {
+  const a = filename.split('.')
+  if (a.length === 1 || (a[0] === '' && a.length === 2)) {
+    return ''
+  }
+  return a.pop().toLowerCase()
+}
+
 async function getData(fields, files) {
   // Extract the JSON from the "JSON" form element
   const data = JSON.parse(fields['json'])
@@ -20,13 +28,18 @@ async function getData(fields, files) {
     shasum.update(fs.readFileSync(file[1].path))
     const sha1Hash = shasum.digest('hex')
 
+    const fileExtension = getFileExtension(file[1].name)
+    const newFilePath =
+      fileExtension !== '' ? `${file[1].path}.${fileExtension}` : file[1].path
+    if (file[1].path !== newFilePath) fs.renameSync(file[1].path, newFilePath)
+
     // Record all the file related fields together in one JSON object for simplicity
     filesToJson.push({
       name: file[1].name,
       type: file[1].type,
       size: file[1].size,
       fileDescription: data.evidence.fileDescriptions[i],
-      path: file[1].path,
+      path: newFilePath,
       sha1: sha1Hash,
       // MongoDB had a 16MB document size limit, but CosmosDB only has a 2MB limit so this isn't going to work.
       //blob: Binary(fs.readFileSync(file[1].path)),
@@ -46,4 +59,4 @@ async function getData(fields, files) {
   return data
 }
 
-module.exports = { getData }
+module.exports = { getData, getFileExtension }


### PR DESCRIPTION
# Description

This renames the files on the server to have the same file extension as the original file. The result will be that (together with #1511) the file attachments on the analyst emails will have correct extensions and be more easily opened.

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
