### PR TITLE
display files even if no description

### DIFF
--- a/f2/src/summary/EvidenceInfoSummary.js
+++ b/f2/src/summary/EvidenceInfoSummary.js
@@ -4,7 +4,6 @@ import { jsx } from '@emotion/core'
 import { Trans } from '@lingui/macro'
 import { Stack, Flex, Box } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
-import { containsData } from '../utils/containsData'
 import { testdata, EditButton } from '../ConfirmationSummary'
 import { H2 } from '../components/header'
 import { Text } from '../components/text'
@@ -44,7 +43,7 @@ export const EvidenceInfoSummary = props => {
             label="confirmationPage.evidence.title.edit"
           />
         </Flex>
-        {containsData(evidence) ? (
+        {evidence.files && evidence.files.length > 0 ? (
           <Stack as="dl" spacing={4} shouldWrapChildren>
             {evidence.files ? (
               <Stack as="dl" spacing={4} shouldWrapChildren>


### PR DESCRIPTION
Fixes #1557

# Description

App was only showing files if there was a description. This fixes that.

# Checklist:

- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
