### PR TITLE
delete "English" and "Francais" words in the pop-up message 

### DIFF
--- a/f2/src/forms/EvidenceInfoForm.js
+++ b/f2/src/forms/EvidenceInfoForm.js
@@ -40,7 +40,7 @@ export const EvidenceInfoForm = props => {
     if (file.size > 4194304) {
       // 4MB in bytes is 4194304.
       alert(
-        'ENGLISH - Warning: Your file size exceeds 4MB. Please reduce the size and try uploading again. \n FRANÇAIS - Alerte : La taille de votre fichier dépasse 4 Mo. Veuillez réduire la taille et essayer de télécharger à nouveau.  ',
+        'Warning: Your file size exceeds 4MB. Please reduce the size and try uploading again. \n Alerte : La taille de votre fichier dépasse 4 Mo. Veuillez réduire la taille et essayer de télécharger à nouveau.',
       )
       return
     }
@@ -166,7 +166,7 @@ export const EvidenceInfoForm = props => {
                       variantColor="blue"
                       onChange={onFilesChange}
                     >
-                      <Trans id="evidencePage.addFileButtom" />
+                      <Trans id="evidencePage.addFileButton" />
                     </FileUpload>
                   </Box>
                   <Alert status="success" backgroundColor="blue.100">

--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -113,7 +113,7 @@
   "devicePage.tellUsMoreExample": "Include details about what was said or done for this to happen.",
   "devicePage.tip": "Consider changing your passwords and contacting the platform where the incident took place.",
   "devicePage.title": "How were your devices or accounts affected?",
-  "evidencePage.addFileButtom": "Add file",
+  "evidencePage.addFileButton": "Add file",
   "evidencePage.backButton": "Go back",
   "evidencePage.detail1": "Screenshots of webpages, conversations, or email threads.",
   "evidencePage.detail2": "Images of receipts, transactions, or packing slips.",

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -113,7 +113,7 @@
   "devicePage.tellUsMoreExample": "Fournissez des détails sur ce qui a été dit ou fait pour que cela se produise.",
   "devicePage.tip": "Pensez à changer vos mots de passe et à contacter la plateforme où l’incident a eu lieu.",
   "devicePage.title": "Répercussions sur vos appareils ou vos comptes",
-  "evidencePage.addFileButtom": "Ajouter un fichier",
+  "evidencePage.addFileButton": "Ajouter un fichier",
   "evidencePage.backButton": "Retour",
   "evidencePage.detail1": "Des captures d’écran de pages Web, de conversations ou de courriels.",
   "evidencePage.detail2": "Des photos de reçus, de transactions ou de bordereaux d’expédition de colis.",


### PR DESCRIPTION
Fixes #1564 (issue)

deleted "English" and "Francais" words in the pop-up message if attached  is larger than 4MB, also corrected the wrong word"buttom" to "button"

- [ ]x I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
