### PR TITLE
Hookup finalfeedback thanks page

### DIFF
--- a/f2/src/ConfirmationPage.js
+++ b/f2/src/ConfirmationPage.js
@@ -106,7 +106,7 @@ const submitToServer = async (data, dispatch) => {
   console.log('Submitting data:', data)
   const response = await postData('/submit', data)
   const reportId = await response.text()
-  dispatch({ type: 'saveFormData', data: { reportId } })
+  dispatch({ type: 'saveFormData', data: { reportId, submitted: true } })
 }
 
 export const ConfirmationPage = () => {

--- a/f2/src/FinalFeedbackPage.js
+++ b/f2/src/FinalFeedbackPage.js
@@ -7,7 +7,6 @@ import { H1 } from './components/header'
 import { TrackPageViews } from './TrackPageViews'
 import { Layout } from './components/layout'
 import { FinalFeedbackForm } from './forms/FinalFeedbackForm'
-import { BackButton } from './components/backbutton'
 import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 
@@ -42,9 +41,6 @@ export const FinalFeedbackPage = () => {
         <Layout>
           <TrackPageViews />
           <Stack spacing={10} shouldWrapChildren>
-            <BackButton route="/thankyoupage">
-              <Trans id="finalFeedback.backButton" />
-            </BackButton>
             <H1>
               <Trans id="finalFeedback.title" />
             </H1>
@@ -52,7 +48,7 @@ export const FinalFeedbackPage = () => {
               onSubmit={data => {
                 submitToServer(data)
                 setState((state.doneFinalFeedback = true))
-                history.push('/thankYouPage')
+                history.push('/finalfeedbackthanks')
               }}
             />
           </Stack>

--- a/f2/src/FinalFeedbackPage.js
+++ b/f2/src/FinalFeedbackPage.js
@@ -48,7 +48,9 @@ export const FinalFeedbackPage = () => {
               onSubmit={data => {
                 submitToServer(data)
                 setState((state.doneFinalFeedback = true))
-                history.push('/finalfeedbackthanks')
+                if (state.formData && state.formData.submitted)
+                  history.push('/thankYouPage')
+                else history.push('/finalfeedbackthanks')
               }}
             />
           </Stack>

--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -133,7 +133,6 @@
   "evidencePage.title": "Attach supporting evidence",
   "fileUpload.added": "File added",
   "fileUpload.removed": "File removed",
-  "finalFeedback.backButton": "Go back",
   "finalFeedback.howCanWeDoBetter.helper": "Do not include any personal or financial details.",
   "finalFeedback.howCanWeDoBetter.label": "How can we do better?",
   "finalFeedback.submit": "Submit",

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -133,7 +133,6 @@
   "evidencePage.title": "Preuves à l’appui",
   "fileUpload.added": "Fichier ajouté",
   "fileUpload.removed": "Fichier enlevé",
-  "finalFeedback.backButton": "Retour",
   "finalFeedback.howCanWeDoBetter.helper": "N’incluez aucune information personnelle ou financière.",
   "finalFeedback.howCanWeDoBetter.label": "Comment pouvons-nous améliorer le service?",
   "finalFeedback.submit": "Soumettre",


### PR DESCRIPTION
Fixes #1592 

# Description

* submitting final feedback (from Cancel or thanks page) leads to finalfeedbackthanks page
* also took out the back button on the finalfeedback page so it'd work with both cancel and thanks

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code

# Required followup work

We should probably just make our Back buttons do a `history.back()`. Though then they're exactly the same as pressing the browser back button, so is there a point?
