### PR TITLE
Don't save malware!

### DIFF
--- a/f2/src/utils/saveBlob.js
+++ b/f2/src/utils/saveBlob.js
@@ -43,19 +43,23 @@ async function saveBlob(data) {
       )
 
       for (var x = 0; x < data.evidence.files.length; x++) {
-        console.log(data.evidence.files[x])
-        const content = fs.readFileSync(data.evidence.files[x].path)
-        // Use SHA1 hash as file name to avoid collisions in blob storage
-        const blobName = data.evidence.files[x].sha1
-        const blockBlobClient = containerClient.getBlockBlobClient(blobName)
-        const uploadBlobResponse = await blockBlobClient.upload(
-          content,
-          content.length,
-        )
-        console.log(
-          `Upload block blob ${blobName} successfully`,
-          uploadBlobResponse.requestId,
-        )
+        if (data.evidence.files[x].malwareIsClean) {
+          console.log(data.evidence.files[x])
+          const content = fs.readFileSync(data.evidence.files[x].path)
+          // Use SHA1 hash as file name to avoid collisions in blob storage
+          const blobName = data.evidence.files[x].sha1
+          const blockBlobClient = containerClient.getBlockBlobClient(blobName)
+          const uploadBlobResponse = await blockBlobClient.upload(
+            content,
+            content.length,
+          )
+          console.log(
+            `Upload block blob ${blobName} successfully`,
+            uploadBlobResponse.requestId,
+          )
+        } else {
+          console.log('Skipping saving file due to malware.')
+        }
       }
     }
   } catch (error) {


### PR DESCRIPTION
Fixes no real issue.

After reviewing how we described things in the IATO and SA&A and how we're handling malware I don't think we're authorized to be keeping malware files submitted to us in our cloud tenant. Let's follow the baseline (CAFC) route of just junking the malware for now.
