### PR TITLE
Clear data thank

### DIFF
--- a/f2/src/ConfirmationPage.js
+++ b/f2/src/ConfirmationPage.js
@@ -116,7 +116,12 @@ export const ConfirmationPage = () => {
   const { i18n } = useLingui()
   if (formData.reportId !== '') {
     dispatch({ type: 'saveFormData', data: { reportId: '' } })
+  } else if (formData.submitted == true) {
+    dispatch({
+      type: 'deleteFormData',
+    })
   }
+
   return (
     <Route
       render={({ history }) => (

--- a/f2/src/ConfirmationPage.js
+++ b/f2/src/ConfirmationPage.js
@@ -116,7 +116,7 @@ export const ConfirmationPage = () => {
   const { i18n } = useLingui()
   if (formData.reportId !== '') {
     dispatch({ type: 'saveFormData', data: { reportId: '' } })
-  } else if (formData.submitted == true) {
+  } else if (formData.submitted === true) {
     dispatch({
       type: 'deleteFormData',
     })


### PR DESCRIPTION
Fixes #1316 (issue)

# Description
 victim has submitted the report and go to ThankYouPage. Then Victim hit back in the browser and went back to confirmation page. The PR clear all the report data and victim can't submit report again even if victim edit the report by using edit button in confirmation button. 
> Give details

# Required followup work

When victim hit back in the browser. it is better going back to landing page, create new issue #1630
# Checklist:

- [ x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)

