### PR TITLE
extract data from formidable manually

### DIFF
--- a/f2/server.js
+++ b/f2/server.js
@@ -130,11 +130,17 @@ app
 
   .post('/submit', (req, res) => {
     availableData.numberOfSubmissions += 1
-    new formidable.IncomingForm().parse(req, (err, fields, files) => {
-      if (err) {
-        console.warn('ERROR', err)
-        throw err
-      }
+    var form = new formidable.IncomingForm()
+    form.parse(req)
+    let files = []
+    let fields = {}
+    form.on('field', (fieldName, fieldValue) => {
+      fields[fieldName] = fieldValue
+    })
+    form.on('file', function(name, file) {
+      files.push(file)
+    })
+    form.on('end', () => {
       uploadData(req, res, fields, files)
     })
   })


### PR DESCRIPTION
Fixes #1638 

# Description

Use formidable to manually extract the form data rather than all in one go. This lets us extract files with the same name without losing any.

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
