### PR TITLE
fix keyboard nav

### DIFF
--- a/f2/src/LocaleSwitcher.js
+++ b/f2/src/LocaleSwitcher.js
@@ -8,7 +8,13 @@ import { A } from './components/link'
 const Toggler = props => {
   const { locale } = props
   return (
-    <A key={locale} padding={0} onClick={() => activate(locale)}>
+    <A
+      key={locale}
+      padding={0}
+      onClick={() => activate(locale)}
+      // eslint-disable-next-line no-script-url
+      href="javascript:;" // otherwise can't navigate to with keyboard
+    >
       {locales[locale]}
     </A>
   )

--- a/f2/src/components/backbutton/index.js
+++ b/f2/src/components/backbutton/index.js
@@ -13,6 +13,8 @@ export const BackButton = ({ variant, variants, variantColor, ...props }) => (
         d="flex"
         alignItems="center"
         onClick={() => history.goBack()}
+        // eslint-disable-next-line no-script-url
+        href="javascript:;" // otherwise can't navigate to with keyboard
         {...props}
       >
         <Icon name="chevron-left" />


### PR DESCRIPTION
Fixes #1659 

# Description

language toggle and go back links were being skipped by keyboard navigation. problem was links without hrefs.

# Required followup work

We should probably tweak the PR templates with a line like "if you've changed or added a component ensure that it is keyboard navigatable"

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
