### PR TITLE
clear file input after alert

### DIFF
--- a/f2/src/forms/EvidenceInfoForm.js
+++ b/f2/src/forms/EvidenceInfoForm.js
@@ -42,6 +42,7 @@ export const EvidenceInfoForm = props => {
       alert(
         'Warning: Your file size exceeds 4MB. Please reduce the size and try uploading again. \n Alerte : La taille de votre fichier dépasse 4 Mo. Veuillez réduire la taille et essayer de télécharger à nouveau.',
       )
+      e.target.value = '' // clear the file input target, to allow the file to be chosen again
       return
     }
     setStatus('fileUpload.added')


### PR DESCRIPTION
Fixes #1615 

# Description

Clear the file input after the alert. Otherwise choosing the same file again doesn't trigger the `onChange` which will show the alert.

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
