### PR TITLE
change "go back" button's height to the same height as "cancel report" button

### DIFF
--- a/f2/src/ConfirmCancelPage.js
+++ b/f2/src/ConfirmCancelPage.js
@@ -44,6 +44,7 @@ export const ConfirmCancelPage = () => {
                   onClick={() => history.goBack()}
                   fontSize={{ base: 'lg', md: 'xl' }}
                   color="black"
+                  height="3rem"
                   variant="link"
                   variantColor="gray"
                   textAlign="center"

--- a/f2/src/ConfirmCancelPage.js
+++ b/f2/src/ConfirmCancelPage.js
@@ -45,7 +45,6 @@ export const ConfirmCancelPage = () => {
                   fontSize={{ base: 'lg', md: 'xl' }}
                   color="black"
                   height="3rem"
-                  variant="link"
                   variantColor="gray"
                   textAlign="center"
                   w={{ base: '100%', md: 'auto' }}


### PR DESCRIPTION

Fixes #1650 (issue)

change "go back" button's height to the same height as "cancel report"… button on confirmCancel page
# Checklist:

- [ x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)

