### PR TITLE
Don't count visitors who aren't referrers (DON'T MERGE UNTIL TOMORROW?)

### DIFF
--- a/f2/server.js
+++ b/f2/server.js
@@ -39,12 +39,12 @@ getAllCerts(uidList)
 const app = express()
 
 const allowedOrigins = [
-  'https://dev.antifraudcentre-centreantifraude.ca',
-  'https://pre.antifraudcentre-centreantifraude.ca',
-  'https://antifraudcentre-centreantifraude.ca',
-  'https://centreantifraude-antifraudcentre.ca',
-  'https://antifraudcentre.ca',
-  'https://centreantifraude.ca',
+  'http://dev.antifraudcentre-centreantifraude.ca',
+  'http://pre.antifraudcentre-centreantifraude.ca',
+  'http://antifraudcentre-centreantifraude.ca',
+  'http://centreantifraude-antifraudcentre.ca',
+  'http://antifraudcentre.ca',
+  'http://centreantifraude.ca',
 ]
 
 const availableData = {
@@ -87,8 +87,13 @@ app.get('/', function(req, res, next) {
         : 'http://www.antifraudcentre-centreantifraude.ca/report-signalez-eng.htm',
     )
   } else {
-    availableData.numberOfRequests += 1
-    availableData.lastRequested = new Date()
+    if (
+      origin !== undefined &&
+      allowedOrigins.indexOf(req.headers.origin.toLowerCase()) > -1
+    ) {
+      availableData.numberOfRequests += 1
+      availableData.lastRequested = new Date()
+    }
     console.log(`New Request. ${JSON.stringify(availableData)}`)
     next()
   }
@@ -130,11 +135,17 @@ app
 
   .post('/submit', (req, res) => {
     availableData.numberOfSubmissions += 1
-    new formidable.IncomingForm().parse(req, (err, fields, files) => {
-      if (err) {
-        console.warn('ERROR', err)
-        throw err
-      }
+    var form = new formidable.IncomingForm()
+    form.parse(req)
+    let files = []
+    let fields = {}
+    form.on('field', (fieldName, fieldValue) => {
+      fields[fieldName] = fieldValue
+    })
+    form.on('file', function(name, file) {
+      files.push(file)
+    })
+    form.on('end', () => {
       uploadData(req, res, fields, files)
     })
   })

--- a/f2/server.js
+++ b/f2/server.js
@@ -39,12 +39,12 @@ getAllCerts(uidList)
 const app = express()
 
 const allowedOrigins = [
-  'http://dev.antifraudcentre-centreantifraude.ca',
-  'http://pre.antifraudcentre-centreantifraude.ca',
-  'http://antifraudcentre-centreantifraude.ca',
-  'http://centreantifraude-antifraudcentre.ca',
-  'http://antifraudcentre.ca',
-  'http://centreantifraude.ca',
+  'https://dev.antifraudcentre-centreantifraude.ca',
+  'https://pre.antifraudcentre-centreantifraude.ca',
+  'https://antifraudcentre-centreantifraude.ca',
+  'https://centreantifraude-antifraudcentre.ca',
+  'https://antifraudcentre.ca',
+  'https://centreantifraude.ca',
 ]
 
 const availableData = {


### PR DESCRIPTION
Something is incrementing our requests counter but not showing up in the app service HTTP logs.  This means it's likely something inside app service (maybe some kind of MS azure monitoring service in the vm or k8s they use in the background). 

Because of this our timer to stagger reports keeps getting reset and we aren't taking new CAFC redirects.