### PR TITLE
Emergency Fix - Don't count non-CAFC referrals

### DIFF
--- a/f2/server.js
+++ b/f2/server.js
@@ -47,6 +47,12 @@ const allowedOrigins = [
   'https://centreantifraude.ca',
 ]
 
+const allowedReferrers = [
+  'antifraudcentre-centreantifraude.ca',
+  'centreantifraude-antifraudcentre.ca',
+  'antifraudcentre.ca',
+  'centreantifraude.ca',
+]
 const availableData = {
   numberOfSubmissions: 0,
   numberOfRequests: 0,
@@ -91,7 +97,7 @@ app.get('/', function(req, res, next) {
     console.log('Referrer:' + referrer)
     if (
       referrer !== undefined &&
-      allowedOrigins.indexOf(referrer.toLowerCase()) > -1
+      allowedReferrers.indexOf(new URL(referrer).host.toLowerCase()) > -1
     ) {
       availableData.numberOfRequests += 1
       availableData.lastRequested = new Date()

--- a/f2/server.js
+++ b/f2/server.js
@@ -88,7 +88,7 @@ app.get('/', function(req, res, next) {
     )
   } else {
     var referrer = req.headers.referer
-    console.log('Refferrer:' + referrer)
+    console.log('Referrer:' + referrer)
     if (
       referrer !== undefined &&
       allowedOrigins.indexOf(referrer.toLowerCase()) > -1

--- a/f2/server.js
+++ b/f2/server.js
@@ -87,8 +87,15 @@ app.get('/', function(req, res, next) {
         : 'http://www.antifraudcentre-centreantifraude.ca/report-signalez-eng.htm',
     )
   } else {
-    availableData.numberOfRequests += 1
-    availableData.lastRequested = new Date()
+    var referrer = req.headers.referer
+    console.log('Refferrer:' + referrer)
+    if (
+      referrer !== undefined &&
+      allowedOrigins.indexOf(referrer.toLowerCase()) > -1
+    ) {
+      availableData.numberOfRequests += 1
+      availableData.lastRequested = new Date()
+    }
     console.log(`New Request. ${JSON.stringify(availableData)}`)
     next()
   }


### PR DESCRIPTION
We currently have a counter of about 1 hour between requests. Only after the hour has passed do we redirect a person from CAFC.

This is a problem because we reset the counter every time the web application is visited. An Internal mechanism from Azure seems to be "visiting" our site every 5 minutes and resetting the counter.  This doesn't show up in our App Service HTTPLogs so it must be an internal mechanism.

Because of this we are effectively not taking any redirects.

This PR adds a check for the referrer to verify the traffic is coming from CAFC before incrementing the counter.

How to test:

To test:


Step 1:

Add a fake DNS entry to your hosts. This makes it so a url points to the web server on YOUR computer.

On Mac OS: edit the file /private/etc/hosts

And add the following entry:

127.0.0.1 centreantifraude.ca

Step 2:

Flush your DNS cache

sudo killall -HUP mDNSResponder 

Step 3: Create a static page with a link to the app:


```
<html>
<head>
</head>
<body>

<a href='http://localhost:3000'>Click me</a>
</body>
</html>
```

Step 4: 

Start a web server on your local machine that serves the static page

Example:

docker run --name nginx -p 80:80 -v /Users/normangosset/projects/fakesite:/usr/share/nginx/html:ro -d nginx

Step 5:

Make sure you are running server.js locally on port 3000

Navigate to http://localhost:80 and click "click me". You should see the following in the console:

Referrer:http://localhost/
New Request. {"numberOfSubmissions":0,"numberOfRequests":0}

Navigate to http://centreantifraude.ca:80 and click :"click me". You should see the following in console:

Referrer:http://centreantifraude.ca/
New Request. {"numberOfSubmissions":0,"numberOfRequests":1,"lastRequested":"2020-03-13T12:25:16.993Z"}