### PR TITLE
Flatten report before submitting

### DIFF
--- a/f2/package-lock.json
+++ b/f2/package-lock.json
@@ -17196,19 +17196,17 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.0.tgz",
+      "integrity": "sha512-6KSMM+cHHzXC/hpldXApL2S8Uz+QZv+tq5o/L0KQYleoG+GcwrnIJhTWC7tCOiKQp8D/fIvryINU1OZCCwevjA==",
       "requires": {
-        "is-buffer": "~2.0.3"
+        "is-buffer": "~2.0.4"
       },
       "dependencies": {
         "is-buffer": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         }
       }
     },
@@ -35732,6 +35730,23 @@
         "flat": "^4.1.0",
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "flat": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+          "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+          "dev": true,
+          "requires": {
+            "is-buffer": "~2.0.3"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
       }
     },
     "yauzl": {

--- a/f2/package.json
+++ b/f2/package.json
@@ -21,6 +21,7 @@
     "express": "^4.17.1",
     "express-rate-limit": "^5.1.1",
     "final-form": "^4.18.7",
+    "flat": "^5.0.0",
     "formidable": "^1.2.1",
     "get-user-locale": "^1.3.0",
     "helmet": "^3.21.3",

--- a/f2/server.js
+++ b/f2/server.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser')
 const path = require('path')
 const formidable = require('formidable')
 const helmet = require('helmet')
+const { unflatten } = require('flat')
 const { encryptAndSend } = require('./src/utils/encryptedEmail')
 const { getCertsAndEmail } = require('./src/utils/ldap')
 const { isAvailable } = require('./src/utils/checkIfAvailable')
@@ -153,7 +154,7 @@ app
     let files = []
     let fields = {}
     form.on('field', (fieldName, fieldValue) => {
-      fields[fieldName] = fieldValue
+      fields[fieldName] = JSON.parse(fieldValue)
     })
     form.on('file', function(name, file) {
       if (files.length >= 3)
@@ -169,6 +170,7 @@ app
       else files.push(file)
     })
     form.on('end', () => {
+      fields = unflatten(fields, { safe: true })
       uploadData(req, res, fields, files)
     })
   })

--- a/f2/src/ConfirmationPage.js
+++ b/f2/src/ConfirmationPage.js
@@ -4,6 +4,7 @@ import { useLingui } from '@lingui/react'
 import { Route } from 'react-router-dom'
 import fetch from 'isomorphic-fetch'
 import { Trans } from '@lingui/macro'
+import flatten from 'flat'
 import { H1 } from './components/header'
 import { P } from './components/paragraph'
 import { Layout } from './components/layout'
@@ -19,8 +20,11 @@ async function postData(url = '', data = {}) {
   // Stick all our collected data into a single form element called json
   // Maybe there's a better way to generate form fields from json?
   // add the files to the formdata object after.
+  const flattenedData = flatten(data, { safe: true })
   var form_data = new FormData()
-  form_data.append('json', JSON.stringify(data))
+  Object.keys(flattenedData).forEach(key => {
+    form_data.append(key, JSON.stringify(flattenedData[key]))
+  })
   if (data.evidence)
     data.evidence.files.forEach(f => form_data.append(f.name, f, f.name))
 

--- a/f2/src/utils/getData.js
+++ b/f2/src/utils/getData.js
@@ -15,10 +15,7 @@ const getFileExtension = filename => {
   return a.pop().toLowerCase()
 }
 
-async function getData(fields, files) {
-  // Extract the JSON from the "JSON" form element
-  const data = JSON.parse(fields['json'])
-
+async function getData(data, files) {
   data.reportId = generateReportId()
   // Clean up the file info we're saving to MongoDB, and record the SHA1 hash so we can find the file in blob storage
   const filesToJson = []


### PR DESCRIPTION
# Description

Flatten report before the app submits it, then unflatten it in the server.
This allows us to submit each piece of data in its own field rather than bundling it all up into one `json` field. Hopefully the WAF will like this more.

# Any new packages installed?

[flat](https://www.npmjs.com/package/flat) (currently 1.8M weekly downloads)

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
- [x] I have added documentation to any modified front-end code. (Or added missing documentation)
