### PR TITLE
remove submissionDate from the analyst email

### DIFF
--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -27,13 +27,13 @@ const formatReportInfo = data => {
         formatLineHtml('Report version:', data.appVersion) +
         formatLineHtml('Flagged:', selfHarmString),
     )
-
-  delete data.reportId // we delete the parts of the data object that we've displayed
-  delete data.submissionTime // so that at the end we can display the rest and ensure that
-  delete data.submissionDate //submissionDate does not needed in analyst report
-  delete data.language // we didn't miss anything
+  // we delete the parts of the data object that we've displayed, so that at the end we can display the rest and ensure that we didn't miss anything
+  delete data.reportId
+  delete data.submissionTime
+  delete data.language
   delete data.appVersion
   delete data.selfHarmWords
+  delete data.submissionDate
   return returnString
 }
 

--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -30,6 +30,7 @@ const formatReportInfo = data => {
 
   delete data.reportId // we delete the parts of the data object that we've displayed
   delete data.submissionTime // so that at the end we can display the rest and ensure that
+  delete data.submissionDate //submissionDate does not needed in analyst report
   delete data.language // we didn't miss anything
   delete data.appVersion
   delete data.selfHarmWords


### PR DESCRIPTION
Fixes #1701 

# Description

> We added submissionDate to the report metadata to allow us to search the database for the number of reports submitted already (in case of a reboot). That field isn't needed in the analyst email - we should delete in formatAnalystEmail() right after we copy the data.

# Any new packages installed?

> no

# Required followup work

> no
# Checklist:

- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
