### PR TITLE
hide edit button if form submitted

### DIFF
--- a/f2/src/components/EditButton/__tests__/EditButton.test.js
+++ b/f2/src/components/EditButton/__tests__/EditButton.test.js
@@ -7,6 +7,7 @@ import { I18nProvider } from '@lingui/react'
 import { i18n } from '@lingui/core'
 import en from '../../../locales/en.json'
 import { MemoryRouter } from 'react-router-dom'
+import { StateProvider, initialState, reducer } from '../../../utils/state'
 
 i18n.load('en', { en })
 i18n.activate('en')
@@ -17,12 +18,49 @@ describe('<EditButton />', () => {
   it('renders', () => {
     render(
       <MemoryRouter>
-        <I18nProvider i18n={i18n}>
-          <ThemeProvider theme={canada}>
-            <EditButton path="/" label="foo" />
-          </ThemeProvider>
-        </I18nProvider>
+        <StateProvider initialState={initialState} reducer={reducer}>
+          <I18nProvider i18n={i18n}>
+            <ThemeProvider theme={canada}>
+              <EditButton path="/" label="foo" />
+            </ThemeProvider>
+          </I18nProvider>
+        </StateProvider>
       </MemoryRouter>,
     )
+  })
+
+  it('shows the edit button if not submitted', () => {
+    const { queryAllByText } = render(
+      <MemoryRouter>
+        <StateProvider initialState={initialState} reducer={reducer}>
+          <I18nProvider i18n={i18n}>
+            <ThemeProvider theme={canada}>
+              <EditButton path="/" label="foo" />
+            </ThemeProvider>
+          </I18nProvider>
+        </StateProvider>
+      </MemoryRouter>,
+    )
+    const editButtons = queryAllByText(/button.edit/)
+    expect(editButtons).toHaveLength(1)
+  })
+
+  it('hides the edit button if submitted', () => {
+    const { queryAllByText } = render(
+      <MemoryRouter>
+        <StateProvider
+          initialState={{ formData: { submitted: true } }}
+          reducer={reducer}
+        >
+          <I18nProvider i18n={i18n}>
+            <ThemeProvider theme={canada}>
+              <EditButton path="/" label="foo" />
+            </ThemeProvider>
+          </I18nProvider>
+        </StateProvider>
+      </MemoryRouter>,
+    )
+    const editButtons = queryAllByText(/button.edit/)
+    expect(editButtons).toHaveLength(0)
   })
 })

--- a/f2/src/components/EditButton/index.js
+++ b/f2/src/components/EditButton/index.js
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types'
 import { Trans } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import { Link } from '../link'
+import { useStateValue } from '../../utils/state'
 
 export const EditButton = ({ path, label }) => {
   const { i18n } = useLingui()
-  return (
+  const [{ formData }] = useStateValue()
+
+  return formData.submitted ? null : (
     <Link to={path} aria-label={i18n._(label)} ml={4}>
       <Trans id="button.edit" />
     </Link>


### PR DESCRIPTION
Fixes #1746 

# Description

Hide edit buttons on confirmation page if user submits and then navigates back.

<img width="440" alt="image" src="https://user-images.githubusercontent.com/8228248/78059943-bccba380-7358-11ea-8dda-5d54ecd77cee.png">


# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
- [x] I have added documentation to any modified front-end code. (Or added missing documentation)
