### PR TITLE
update next page text for consent page

### DIFF
--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -264,7 +264,7 @@
   "pageNotFound.message": "Sorry, the page you were trying to view does not exist.",
   "privacyConsentInfoForm.linkOut": "Privacy statement",
   "privacyConsentInfoForm.nextButton": "Continue",
-  "privacyConsentInfoForm.nextPage": "Next: How did the incident start?",
+  "privacyConsentInfoForm.nextPage": "Next: Report anonymously?",
   "privacyConsentInfoForm.period": ".",
   "privacyConsentInfoForm.warning": "Please accept the terms of the Privacy statement. Check the box to continue.",
   "privacyConsentInfoForm.yes": "I accept the terms of the ",

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -264,7 +264,7 @@
   "pageNotFound.message": "Désolé, la page que vous essayiez de voir n’existe pas.",
   "privacyConsentInfoForm.linkOut": "Déclaration de confidentialité",
   "privacyConsentInfoForm.nextButton": "Continuer",
-  "privacyConsentInfoForm.nextPage": "Étape suivante : Comment l’incident a-t-il commencé?",
+  "privacyConsentInfoForm.nextPage": "Étape suivante : Aimeriez-vous rester anonyme?",
   "privacyConsentInfoForm.period": ".",
   "privacyConsentInfoForm.warning": "Veuillez accepter les conditions de la Déclaration de confidentialité. Cochez la case pour continuer.",
   "privacyConsentInfoForm.yes": "J’accepte les conditions de la ",


### PR DESCRIPTION
Fixes #1766

# Description

change the "next page" text on the consent page, since now there's the anonymous page there.

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
- [x] I have added documentation to any modified front-end code. (Or added missing documentation)
