### PR TITLE
remove unused optionOther field

### DIFF
--- a/f2/src/ConfirmationSummary.js
+++ b/f2/src/ConfirmationSummary.js
@@ -33,7 +33,6 @@ export const testdata = {
     },
     whatWasAffected: {
       affectedOptions: [],
-      optionOther: '',
     },
     moneyLost: {
       demandedMoney: '',

--- a/f2/src/forms/WhatWasAffectedForm.js
+++ b/f2/src/forms/WhatWasAffectedForm.js
@@ -11,7 +11,7 @@ import { FormArrayControl } from '../components/FormArrayControl'
 import { ErrorSummary } from '../components/ErrorSummary'
 import { Text } from '../components/text'
 
-const validate = values => {
+const validate = (values) => {
   const errors = {}
   //condition for an error to occur: append a lingui id to the list of error
   if (!values.affectedOptions || values.affectedOptions.length < 1) {
@@ -34,17 +34,16 @@ export const whatWasAffectedPages = [
   { key: 'whatWasAffectedForm.other', url: '' },
 ]
 
-export const WhatWasAffectedForm = props => {
+export const WhatWasAffectedForm = (props) => {
   const { i18n } = useLingui()
 
   const [data] = useStateValue()
   const whatWasAffected = {
     affectedOptions: [],
     ...data.formData.whatWasAffected,
-    optionOther: '',
   }
 
-  const affectedOptions = whatWasAffectedPages.map(page => page.key)
+  const affectedOptions = whatWasAffectedPages.map((page) => page.key)
 
   return (
     <React.Fragment>
@@ -64,7 +63,7 @@ export const WhatWasAffectedForm = props => {
 
       <Form
         initialValues={whatWasAffected}
-        onSubmit={values => {
+        onSubmit={(values) => {
           props.onSubmit(values)
         }}
         validate={validate}
@@ -91,7 +90,7 @@ export const WhatWasAffectedForm = props => {
               helperText={<Trans id="whatWasAffectedForm.optionsHelpText" />}
               errorMessage={<Trans id="whatWasAffectedForm.warning" />}
             >
-              {affectedOptions.map(key => {
+              {affectedOptions.map((key) => {
                 return (
                   <React.Fragment key={key}>
                     <CheckboxAdapter

--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -79,8 +79,8 @@ const formatIncidentInformation = (data) => {
     formatLineHtml('Occurrence date:            ', occurenceString) +
     formatLineHtml('Frequency of occurrence:    ', freqString) +
     formatLineHtml('Method of communication:    ', methodOfCommsString) +
-    formatLineHtml('What could be affected:     ', affectedString) +
-    delete data.howdiditstart.startDay
+    formatLineHtml('What could be affected:     ', affectedString)
+  delete data.howdiditstart.startDay
   delete data.howdiditstart.startMonth
   delete data.howdiditstart.startYear
   delete data.howdiditstart.howManyTimes

--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -80,18 +80,12 @@ const formatIncidentInformation = (data) => {
     formatLineHtml('Frequency of occurrence:    ', freqString) +
     formatLineHtml('Method of communication:    ', methodOfCommsString) +
     formatLineHtml('What could be affected:     ', affectedString) +
-    formatLineHtml(
-      'What could be affected:     ',
-      data.whatWasAffected.optionOther,
-    )
-
-  delete data.howdiditstart.startDay
+    delete data.howdiditstart.startDay
   delete data.howdiditstart.startMonth
   delete data.howdiditstart.startYear
   delete data.howdiditstart.howManyTimes
   delete data.howdiditstart.howDidTheyReachYou
   delete data.whatWasAffected.affectedOptions
-  delete data.whatWasAffected.optionOther
   return formatSection('Incident information', rows)
 }
 


### PR DESCRIPTION
Fixes #1762

# Description

We got rid of the `whatWasAffected` `optionOther` field a while ago but didn't take the (now always empty field) out of the report data. This PR removes it everywhere.


# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
- [x] I have added documentation to any modified front-end code. (Or added missing documentation)
