### PR TITLE
add instructions for getting unencrypted analyst email

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ npm run dev
 ### Frontend and backend
 
 ```sh
-npm run build
-node server.js
+npm run prod
 ```
 
 ### Run project with Docker
@@ -136,6 +135,13 @@ docker run -p 3000:3000 rac
 ### Getting the analyst email yourself
 
 It is often useful to quickly see what the analyst email looks like. If the `LDAP_UID` environment variable is not set and the user provides their email address on the contact info screen then the server will send the analyst email unencrypted to the user. This is solely for development purposes. Note that the review apps are configured this way.
+
+To do this locally:
+
+- ensure that `LDAP_UID` is not set in your terminal environment nor in your `.env` file
+- run `npm run prod`
+- fill out the report and include your email address on http://localhost:3000/contactinfo
+- you should receive the generated report email
 
 ## Load testing the frontend
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ docker build -t rac .
 docker run -p 3000:3000 rac
 ```
 
+### Getting the analyst email yourself
+
+It is often useful to quickly see what the analyst email looks like. If the `LDAP_UID` environment variable is not set and the user provides their email address on the contact info screen then the server will send the analyst email unencrypted to the user. This is solely for development purposes. Note that the review apps are configured this way.
+
 ## Load testing the frontend
 
 There are simple scripts to load test the frontend. They use the [k6](https://docs.k6.io) package, which must first be installed (see (https://docs.k6.io/docs/installation)


### PR DESCRIPTION
Fixes #1702

# Description

add info the README about getting the analyst emails yourself

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
- [x] I have added documentation to any modified front-end code. (Or added missing documentation)
