### PR TITLE
Import EditButton from components on summary block pages

### DIFF
--- a/f2/src/ConfirmationSummary.js
+++ b/f2/src/ConfirmationSummary.js
@@ -3,8 +3,6 @@ import { jsx } from '@emotion/core'
 import React from 'react'
 import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
-import { withProps } from 'recompose'
-import { EditButton as EditButtonAlias } from './components/EditButton'
 import { HowDidItStartSummary } from './summary/HowDidItStartSummary'
 import { BusinessInfoSummary } from './summary/BusinessInfoSummary'
 import { ContactInfoSummary } from './summary/ContactInfoSummary'
@@ -68,11 +66,6 @@ export const testdata = {
     contactInfo: { fullName: '', email: '', phone: '' },
   },
 }
-
-// TODO: Moved the EditButton into the components folder.
-// All summary blocks are still importing EditButton from this file.
-// Leaving this here as an alias.
-export const EditButton = withProps({})(EditButtonAlias)
 
 export const ConfirmationSummary = () => {
   const [data, dispatch] = useStateValue()

--- a/f2/src/summary/BusinessInfoSummary.js
+++ b/f2/src/summary/BusinessInfoSummary.js
@@ -5,12 +5,13 @@ import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
 import { Text } from '../components/text'
 
-export const BusinessInfoSummary = props => {
+export const BusinessInfoSummary = (props) => {
   const [data] = useStateValue()
 
   const businessInfo = {

--- a/f2/src/summary/ContactInfoSummary.js
+++ b/f2/src/summary/ContactInfoSummary.js
@@ -5,12 +5,13 @@ import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
 import { Text } from '../components/text'
 
-export const ContactInfoSummary = props => {
+export const ContactInfoSummary = (props) => {
   const [data] = useStateValue()
   const contactInfo = {
     ...testdata.formData.contactInfo, //Remove after done testing

--- a/f2/src/summary/DevicesSummary.js
+++ b/f2/src/summary/DevicesSummary.js
@@ -5,12 +5,13 @@ import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
 import { Text } from '../components/text'
 
-export const DevicesSummary = props => {
+export const DevicesSummary = (props) => {
   const [data] = useStateValue()
 
   const devices = {

--- a/f2/src/summary/EvidenceInfoSummary.js
+++ b/f2/src/summary/EvidenceInfoSummary.js
@@ -4,11 +4,12 @@ import { jsx } from '@emotion/core'
 import { Trans } from '@lingui/macro'
 import { Stack, Flex, Box } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { Text } from '../components/text'
 
-export const EvidenceInfoSummary = props => {
+export const EvidenceInfoSummary = (props) => {
   const [data] = useStateValue()
 
   const evidence = {

--- a/f2/src/summary/HowDidItStartSummary.js
+++ b/f2/src/summary/HowDidItStartSummary.js
@@ -7,13 +7,14 @@ import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
 import { formatDate } from '../utils/formatDate'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
 import { Text } from '../components/text'
 import { formatList } from '../utils/formatList'
 
-export const HowDidItStartSummary = props => {
+export const HowDidItStartSummary = (props) => {
   const [data] = useStateValue()
   const { i18n } = useLingui()
   const summary = []
@@ -26,7 +27,7 @@ export const HowDidItStartSummary = props => {
 
   if (howdiditstart.howDidTheyReachYou.length > 0) {
     //Obtain all the array data into the summary array
-    howdiditstart.howDidTheyReachYou.map(key =>
+    howdiditstart.howDidTheyReachYou.map((key) =>
       summary.push(
         key === 'howDidTheyReachYou.others' && howdiditstart.others !== ''
           ? howdiditstart.others

--- a/f2/src/summary/InformationSummary.js
+++ b/f2/src/summary/InformationSummary.js
@@ -4,7 +4,8 @@ import { jsx } from '@emotion/core'
 import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
 import { useLingui } from '@lingui/react'
@@ -12,7 +13,7 @@ import { Text } from '../components/text'
 import { formatList } from '../utils/formatList'
 import { containsData } from '../utils/containsData'
 
-export const InformationSummary = props => {
+export const InformationSummary = (props) => {
   const [data] = useStateValue()
   const { i18n } = useLingui()
 
@@ -22,7 +23,7 @@ export const InformationSummary = props => {
   }
 
   //push all select entities into the stack and if 'other' is selected, push the value of other.
-  const infoReqSummary = personalInformation.typeOfInfoReq.map(key =>
+  const infoReqSummary = personalInformation.typeOfInfoReq.map((key) =>
     key === 'typeOfInfoReq.other' && personalInformation.infoReqOther !== ''
       ? personalInformation.infoReqOther
       : i18n._(key),
@@ -34,11 +35,12 @@ export const InformationSummary = props => {
   })
 
   //push all select entities into the stack and if 'other' is selected, push the value of other.
-  const infoObtainedSummary = personalInformation.typeOfInfoObtained.map(key =>
-    key === 'typeOfInfoObtained.other' &&
-    personalInformation.infoObtainedOther !== ''
-      ? personalInformation.infoObtainedOther
-      : i18n._(key),
+  const infoObtainedSummary = personalInformation.typeOfInfoObtained.map(
+    (key) =>
+      key === 'typeOfInfoObtained.other' &&
+      personalInformation.infoObtainedOther !== ''
+        ? personalInformation.infoObtainedOther
+        : i18n._(key),
   )
   const infoObtainedLine = formatList(infoObtainedSummary, {
     pair: i18n._('default.pair'),

--- a/f2/src/summary/LocationInfoSummary.js
+++ b/f2/src/summary/LocationInfoSummary.js
@@ -5,12 +5,13 @@ import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
 import { Text } from '../components/text'
 
-export const LocationInfoSummary = props => {
+export const LocationInfoSummary = (props) => {
   const [data] = useStateValue()
   const location = {
     ...testdata.formData.location, //Remove after done testing

--- a/f2/src/summary/MoneyLostInfoSummary.js
+++ b/f2/src/summary/MoneyLostInfoSummary.js
@@ -6,14 +6,15 @@ import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
 import { formatDate } from '../utils/formatDate'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
 import { Text } from '../components/text'
 import { formatList } from '../utils/formatList'
 import { useLingui } from '@lingui/react'
 
-export const MoneyLostInfoSummary = props => {
+export const MoneyLostInfoSummary = (props) => {
   const [data] = useStateValue()
   const { i18n } = useLingui()
   const methodPaymentSummary = []
@@ -24,7 +25,7 @@ export const MoneyLostInfoSummary = props => {
     ...data.formData.moneyLost,
   }
 
-  moneyLost.methodPayment.map(key =>
+  moneyLost.methodPayment.map((key) =>
     methodPaymentSummary.push(
       key === 'methodPayment.other' ? moneyLost.methodOther : i18n._(key),
     ),

--- a/f2/src/summary/SuspectCluesSummary.js
+++ b/f2/src/summary/SuspectCluesSummary.js
@@ -5,12 +5,13 @@ import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { DescriptionListItem } from '../components/DescriptionListItem'
 import { Text } from '../components/text'
 
-export const SuspectCluesSummary = props => {
+export const SuspectCluesSummary = (props) => {
   const [data] = useStateValue()
   const suspectClues = {
     ...testdata.formData.suspectClues,

--- a/f2/src/summary/WhatHappenedSummary.js
+++ b/f2/src/summary/WhatHappenedSummary.js
@@ -5,11 +5,12 @@ import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { Text } from '../components/text'
 
-export const WhatHappenedSummary = props => {
+export const WhatHappenedSummary = (props) => {
   const [data] = useStateValue()
 
   const whatHappened = {

--- a/f2/src/summary/WhatWasAffectedSummary.js
+++ b/f2/src/summary/WhatWasAffectedSummary.js
@@ -5,13 +5,14 @@ import { Trans } from '@lingui/macro'
 import { Stack, Flex } from '@chakra-ui/core'
 import { useStateValue } from '../utils/state'
 import { containsData } from '../utils/containsData'
-import { testdata, EditButton } from '../ConfirmationSummary'
+import { testdata } from '../ConfirmationSummary'
+import { EditButton } from '../components/EditButton'
 import { H2 } from '../components/header'
 import { useLingui } from '@lingui/react'
 import { Text } from '../components/text'
 import { formatList } from '../utils/formatList'
 
-export const WhatWasAffectedSummary = props => {
+export const WhatWasAffectedSummary = (props) => {
   const { i18n } = useLingui()
 
   const [data] = useStateValue()
@@ -21,7 +22,7 @@ export const WhatWasAffectedSummary = props => {
     ...data.formData.whatWasAffected,
   }
 
-  const summaryOptions = impact.affectedOptions.map(key =>
+  const summaryOptions = impact.affectedOptions.map((key) =>
     i18n._(key).toLowerCase(),
   )
   const summaryLine = formatList(summaryOptions, {


### PR DESCRIPTION
Fixes #1742

# Description

> On the confirmationSummaryPage, we used to export EditButton
This component has been moved into the components folder.
We are exporting an alias of EditButton from confirmationSummaryPage to avoid breaking all summary blocks pages.

# Any new packages installed?

> no

# Required followup work

> no

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
- [x] I have added documentation to any modified front-end code. (Or added missing documentation)
