### PR TITLE
Change CAFC redirect to https

### DIFF
--- a/f2/server.js
+++ b/f2/server.js
@@ -113,8 +113,8 @@ app.get('/', async function (req, res, next) {
     console.warn('Warning: redirecting request to CAFC')
     res.redirect(
       req.subdomains.includes('signalez')
-        ? 'http://www.antifraudcentre-centreantifraude.ca/report-signalez-fra.htm'
-        : 'http://www.antifraudcentre-centreantifraude.ca/report-signalez-eng.htm',
+        ? 'https://www.antifraudcentre-centreantifraude.ca/report-signalez-fra.htm'
+        : 'https://www.antifraudcentre-centreantifraude.ca/report-signalez-eng.htm',
     )
   } else {
     // temporary debugging code


### PR DESCRIPTION
I was looking at the code and I saw that these URL were still HTTP.  The source site is redirecting to https automatically now, so this PR has little consequence I suppose, but might as well correct it.

Todo: Test the change and make sure the redirect still works?