### PR TITLE
exclude .png file been uploaded

### DIFF
--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -152,7 +152,7 @@
   "evidencePage.details": "If you can, include things such as:",
   "evidencePage.fileDescription": "Describe what this file shows",
   "evidencePage.fileSize": "You can add a maximum of 3 files, each up to 4 MB in size each.",
-  "evidencePage.fileTypes": "jpg, .jpeg, .doc, .xls, .pdf, and .txt.",
+  "evidencePage.fileTypes": "jpg, .jpeg, .doc, .docx, .xls, .xlsx .pdf, .txt and .rtf.",
   "evidencePage.fileWarning": "Files will be checked for safe content.",
   "evidencePage.intro": "It’s okay if you didn’t keep any documentation from the incident. You can skip to the next section.",
   "evidencePage.maxFileWarning": "You have added the maximum number of files allowed.",

--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -152,7 +152,7 @@
   "evidencePage.details": "If you can, include things such as:",
   "evidencePage.fileDescription": "Describe what this file shows",
   "evidencePage.fileSize": "You can add a maximum of 3 files, each up to 4 MB in size each.",
-  "evidencePage.fileTypes": ".png, .jpeg, .doc, .xls, .pdf, and .txt.",
+  "evidencePage.fileTypes": "jpg, .jpeg, .doc, .xls, .pdf, and .txt.",
   "evidencePage.fileWarning": "Files will be checked for safe content.",
   "evidencePage.intro": "It’s okay if you didn’t keep any documentation from the incident. You can skip to the next section.",
   "evidencePage.maxFileWarning": "You have added the maximum number of files allowed.",

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -152,7 +152,7 @@
   "evidencePage.details": "Si toutefois vous le pouvez, incluez des indices tels que :",
   "evidencePage.fileDescription": "Décrivez ce que montre ce fichier.",
   "evidencePage.fileSize": "Vous pouvez ajouter un maximum de 3 fichiers, chacun d’une taille maximale de 4 Mo.",
-  "evidencePage.fileTypes": ".png, .jpeg, .doc, .xls, .pdf, et .txt.",
+  "evidencePage.fileTypes": ".jpg, .jpeg, .doc, .xls, .pdf, et .txt.",
   "evidencePage.fileWarning": "Les fichiers seront vérifiés pour nous assurer que leur contenu est sûr.",
   "evidencePage.intro": "Ce n’est pas grave si vous n’avez pas conservé de documents liés à l’incident. Vous pouvez passer à la section suivante.",
   "evidencePage.maxFileWarning": "Vous avez ajouté le nombre maximum de fichiers possibles.",

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -152,7 +152,7 @@
   "evidencePage.details": "Si toutefois vous le pouvez, incluez des indices tels que :",
   "evidencePage.fileDescription": "Décrivez ce que montre ce fichier.",
   "evidencePage.fileSize": "Vous pouvez ajouter un maximum de 3 fichiers, chacun d’une taille maximale de 4 Mo.",
-  "evidencePage.fileTypes": ".jpg, .jpeg, .doc, .xls, .pdf, et .txt.",
+  "evidencePage.fileTypes": ".jpg, .jpeg, .doc, .docx, .xls, .xlsx .pdf, .txt, et .rtf.",
   "evidencePage.fileWarning": "Les fichiers seront vérifiés pour nous assurer que leur contenu est sûr.",
   "evidencePage.intro": "Ce n’est pas grave si vous n’avez pas conservé de documents liés à l’incident. Vous pouvez passer à la section suivante.",
   "evidencePage.maxFileWarning": "Vous avez ajouté le nombre maximum de fichiers possibles.",

--- a/f2/src/utils/acceptableFiles.js
+++ b/f2/src/utils/acceptableFiles.js
@@ -1,14 +1,14 @@
-const acceptableExtensions = '.png, .jpg, .jpeg, .doc, .docx, .xls, .xlsx, .pdf, .txt, .rtf'
+const acceptableExtensions = '.jpg, .jpeg, .doc, .docx, .xls, .xlsx, .pdf, .txt, .rtf'
   .split(',')
-  .map(ext => ext.trim())
+  .map((ext) => ext.trim())
 
-const getExtension = fileName =>
+const getExtension = (fileName) =>
   fileName.includes('.') ? fileName.split('.').pop() : ''
 
-const fileExtensionPasses = fileName => {
+const fileExtensionPasses = (fileName) => {
   return acceptableExtensions.indexOf('.' + getExtension(fileName)) > -1
 }
 
-const fileSizePasses = fileSize => fileSize <= 4 * 1024 * 1024
+const fileSizePasses = (fileSize) => fileSize <= 4 * 1024 * 1024
 
 module.exports = { acceptableExtensions, fileExtensionPasses, fileSizePasses }


### PR DESCRIPTION
Fixes #1857

# Description
as suggested by RCMP Stephanie Gauthier: 
.png files were not included in the original list of file types accepted by the CAFC so suggestion that these should be excluded from our app.
This PR is to forbid .png file to be uploaded and add more permitted file type in the String to inform victim

# Checklist:

- [ x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ x] I have added a comment to any confusing code

