### PR TITLE
Move submitted and reportId out of formData

### DIFF
--- a/f2/src/ConfirmationPage.js
+++ b/f2/src/ConfirmationPage.js
@@ -38,11 +38,18 @@ async function postData(url = '', data = {}) {
     redirect: 'follow',
     referrer: 'no-referrer',
     body: form_data,
+  }).catch(function (error) {
+    console.log({ error })
   })
-  return response
+  return response ? response.text() : 'fetch failed'
 }
 
-const prepFormData = (formData, language) => {
+const prepFormData = (formDataOrig, language) => {
+  // this allows us to go directly to the confirmation page during debugging
+  const formData = {
+    ...formDefaults,
+    ...formDataOrig,
+  }
   formData.appVersion = process.env.REACT_APP_VERSION
     ? process.env.REACT_APP_VERSION.slice(0, 7)
     : 'no version'
@@ -97,8 +104,7 @@ const prepFormData = (formData, language) => {
 
 const submitToServer = async (data, dispatch) => {
   console.log('Submitting data:', data)
-  const response = await postData('/submit', data)
-  const reportId = await response.text()
+  const reportId = await postData('/submit', data)
   const submitted = reportId && reportId.startsWith('NCFRS-')
   dispatch({ type: 'saveReportId', data: reportId })
   dispatch({ type: 'saveSubmitted', data: submitted })
@@ -126,6 +132,8 @@ export const ConfirmationPage = () => {
             <ConfirmationSummary />
             <ConfirmationForm
               onSubmit={() => {
+                dispatch({ type: 'saveReportId', data: undefined })
+                dispatch({ type: 'saveSubmitted', data: undefined })
                 submitToServer(prepFormData(formData, i18n.locale), dispatch)
                 history.push('/thankYouPage')
               }}

--- a/f2/src/ConfirmationPage.js
+++ b/f2/src/ConfirmationPage.js
@@ -100,7 +100,8 @@ const submitToServer = async (data, dispatch) => {
   const response = await postData('/submit', data)
   const reportId = await response.text()
   const submitted = reportId && reportId.startsWith('NCFRS-')
-  dispatch({ type: 'saveFormData', data: { reportId, submitted } })
+  dispatch({ type: 'saveReportId', data: reportId })
+  dispatch({ type: 'saveSubmitted', data: submitted })
 }
 
 export const ConfirmationPage = () => {

--- a/f2/src/FinalFeedbackPage.js
+++ b/f2/src/FinalFeedbackPage.js
@@ -27,7 +27,7 @@ async function postData(url = '', data = {}) {
   return await response
 }
 
-const submitToServer = async data => {
+const submitToServer = async (data) => {
   console.log('Submitting finalFeedback:', data)
   await postData('/submitFeedback', data)
 }
@@ -45,10 +45,10 @@ export const FinalFeedbackPage = () => {
               <Trans id="finalFeedback.title" />
             </H1>
             <FinalFeedbackForm
-              onSubmit={data => {
+              onSubmit={(data) => {
                 submitToServer(data)
                 setState((state.doneFinalFeedback = true))
-                if (state.formData && state.formData.submitted)
+                if (state.formData && state.submitted)
                   history.push('/thankYouPage')
                 else history.push('/finalfeedbackthanks')
               }}

--- a/f2/src/FinalFeedbackPage.js
+++ b/f2/src/FinalFeedbackPage.js
@@ -48,8 +48,7 @@ export const FinalFeedbackPage = () => {
               onSubmit={(data) => {
                 submitToServer(data)
                 setState((state.doneFinalFeedback = true))
-                if (state.formData && state.submitted)
-                  history.push('/thankYouPage')
+                if (state.submitted) history.push('/thankYouPage')
                 else history.push('/finalfeedbackthanks')
               }}
             />

--- a/f2/src/ThankYouPage.js
+++ b/f2/src/ThankYouPage.js
@@ -20,14 +20,12 @@ import { Alert } from './components/Messages'
 
 export const ThankYouPage = () => {
   const { i18n } = useLingui()
-  const [state] = useStateValue()
-  const [data] = useStateValue()
+
+  const [state, dispatch] = useStateValue()
 
   const contactInfo = {
-    ...data.formData.contactInfo,
+    ...state.formData.contactInfo,
   }
-
-  const [, dispatch] = useStateValue()
 
   // Message displayed on Thank you Page
   const reportId = state.reportId

--- a/f2/src/ThankYouPage.js
+++ b/f2/src/ThankYouPage.js
@@ -30,7 +30,7 @@ export const ThankYouPage = () => {
   const [, dispatch] = useStateValue()
 
   // Message displayed on Thank you Page
-  const reportId = state.formData.reportId
+  const reportId = state.reportId
   const submissionInProgress = !reportId || reportId === ''
   const submissionSucceeded =
     !submissionInProgress && reportId.startsWith('NCFRS-')

--- a/f2/src/components/EditButton/__tests__/EditButton.test.js
+++ b/f2/src/components/EditButton/__tests__/EditButton.test.js
@@ -48,10 +48,7 @@ describe('<EditButton />', () => {
   it('hides the edit button if submitted', () => {
     const { queryAllByText } = render(
       <MemoryRouter>
-        <StateProvider
-          initialState={{ formData: { submitted: true } }}
-          reducer={reducer}
-        >
+        <StateProvider initialState={{ submitted: true }} reducer={reducer}>
           <I18nProvider i18n={i18n}>
             <ThemeProvider theme={canada}>
               <EditButton path="/" label="foo" />

--- a/f2/src/components/EditButton/index.js
+++ b/f2/src/components/EditButton/index.js
@@ -7,9 +7,9 @@ import { useStateValue } from '../../utils/state'
 
 export const EditButton = ({ path, label }) => {
   const { i18n } = useLingui()
-  const [{ formData }] = useStateValue()
+  const [{ submitted }] = useStateValue()
 
-  return formData.submitted ? null : (
+  return submitted ? null : (
     <Link to={path} aria-label={i18n._(label)} ml={4}>
       <Trans id="button.edit" />
     </Link>

--- a/f2/src/forms/ConfirmationForm.js
+++ b/f2/src/forms/ConfirmationForm.js
@@ -9,8 +9,8 @@ import { Well } from '../components/Messages'
 import { NextAndCancelButtons } from '../components/next-and-cancel-buttons'
 import { useStateValue } from '../utils/state'
 
-export const ConfirmationForm = props => {
-  const [{ formData }] = useStateValue()
+export const ConfirmationForm = (props) => {
+  const [{ reportId, submitted }] = useStateValue()
   return (
     <React.Fragment>
       <Form
@@ -22,11 +22,11 @@ export const ConfirmationForm = props => {
             shouldWrapChildren
             spacing={6}
           >
-            {formData.submitted ? (
+            {submitted ? (
               <Well variantColor="blue">
                 <Trans
                   id="confirmationPage.thankyou"
-                  values={{ reference: formData.reportId }}
+                  values={{ reference: reportId }}
                 />
               </Well>
             ) : (

--- a/f2/src/forms/defaultValues.js
+++ b/f2/src/forms/defaultValues.js
@@ -3,7 +3,7 @@ const formDefaults = {
   prodVersion: '',
   appVersion: '',
   consent: { consentOptions: [] },
-  anonymous: { anonymousOptions: [] },
+  anonymous: { anonymousOptions: ['anonymousPage.no'] },
   howdiditstart: {
     howDidTheyReachYou: [],
     email: '',

--- a/f2/src/utils/state.js
+++ b/f2/src/utils/state.js
@@ -36,6 +36,16 @@ export const reducer = (state, action) => {
         ...state,
         doneForms: action.data,
       }
+    case 'saveSubmitted':
+      return {
+        ...state,
+        submitted: action.data,
+      }
+    case 'saveReportId':
+      return {
+        ...state,
+        reportId: action.data,
+      }
     default:
       return state
   }

--- a/f2/src/utils/state.js
+++ b/f2/src/utils/state.js
@@ -30,6 +30,8 @@ export const reducer = (state, action) => {
       return {
         ...state,
         formData: { ...initialState.formData },
+        submitted: false,
+        reportId: undefined,
       }
     case 'saveDoneForms':
       return {


### PR DESCRIPTION
# Description

Fixes a bug where second submission (ie trying after a first failure) would always be rejected.

To test locally:

- `npm run prod` and go through app. Submission works.
- Go back with browser back button. Confirmation page knows you've already submitted and has your report id at the bottom.
- Now go forward to the thankyou page and "create a new report". Verify that this still works and you can submit a new report.
- Next go back to the landing page, and stop `server.js` in your terminal. Fill out the report. The submission should fail (since the server isn't running).
- Click "Back to your report" - the confirmation page should have Edit links and a submit button.
- Run `node server.js` in your terminal and wait a few seconds for it to boot.
- Click "Submit report". This time the submission should succeed.


# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
- [x] I have added documentation to any modified front-end code. (Or added missing documentation)
