### PR TITLE
add email validation

### DIFF
--- a/f2/src/forms/ContactInfoForm.js
+++ b/f2/src/forms/ContactInfoForm.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import React from 'react'
-import addrs from 'email-addresses'
 import PropTypes from 'prop-types'
 import { jsx } from '@emotion/core'
 import { Trans } from '@lingui/macro'

--- a/f2/src/forms/ContactInfoForm.js
+++ b/f2/src/forms/ContactInfoForm.js
@@ -22,11 +22,10 @@ export const validate = (values) => {
   const errors = {}
   //condition for an error to occur: append a lingui id to the list of error
   // reference https://www.w3resource.com/javascript/form/email-validation.php
-  // if (!/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(values.email)) {
-  if (!/^\w+([-]?\w+)*@\w+([-]?\w+)*(\.\w{2,3})+$/.test(values.email)) {
+  if (!/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(values.email)) {
+    // if (!/^\w+([\.-]?\w+)*@\w+([-]?\w+)*(\w{2,3})+$/.test(values.email)) {
     errors.email = 'contactinfoForm.email.warning'
   }
-
   // from https://www.w3resource.com/javascript/form/phone-no-validation.php
   const phoneRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/
   // if (values.phone !== '' && !new RegExp(phoneRegex).test(values.phone)) {

--- a/f2/src/forms/ContactInfoForm.js
+++ b/f2/src/forms/ContactInfoForm.js
@@ -22,7 +22,8 @@ export const validate = (values) => {
   const errors = {}
   //condition for an error to occur: append a lingui id to the list of error
   // reference https://www.w3resource.com/javascript/form/email-validation.php
-  if (!/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(values.email)) {
+  // if (!/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(values.email)) {
+  if (!/^\w+([-]?\w+)*@\w+([-]?\w+)*(\.\w{2,3})+$/.test(values.email)) {
     errors.email = 'contactinfoForm.email.warning'
   }
 

--- a/f2/src/forms/ContactInfoForm.js
+++ b/f2/src/forms/ContactInfoForm.js
@@ -22,11 +22,14 @@ import { formDefaults } from './defaultValues'
 export const validate = (values) => {
   const errors = {}
   //condition for an error to occur: append a lingui id to the list of error
-  if (values.email !== '' && addrs(values.email) == null) {
+  // reference https://www.w3resource.com/javascript/form/email-validation.php
+  if (!/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(values.email)) {
     errors.email = 'contactinfoForm.email.warning'
   }
+
   // from https://www.w3resource.com/javascript/form/phone-no-validation.php
   const phoneRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/
+  // if (values.phone !== '' && !new RegExp(phoneRegex).test(values.phone)) {
   if (values.phone !== '' && !new RegExp(phoneRegex).test(values.phone)) {
     errors.phone = 'contactinfoForm.phone.warning'
   }

--- a/f2/src/forms/__tests__/ContactInfoForm.test.js
+++ b/f2/src/forms/__tests__/ContactInfoForm.test.js
@@ -39,10 +39,20 @@ describe('validation', () => {
     expect(validate({ email: 'aaaa@aaa.com' }).email).toBeUndefined()
     expect(validate({ email: 'aaa.aaa@aaa.com' }).email).toBeUndefined()
     expect(validate({ email: 'aaa@aaa-aaa.com' }).email).toBeUndefined()
+    expect(validate({ email: 'mysite@you.me.net' }).email).toBeUndefined()
   })
 
   it('fails incorrect email address', () => {
     expect(validate({ email: 'aaaaaa.com' }).email).not.toBeUndefined()
+    expect(validate({ email: 'mysite@.com.my' }).email).not.toBeUndefined()
+    expect(validate({ email: '@you.me.net ' }).email).not.toBeUndefined()
+    expect(validate({ email: 'mysite123@gmail.b' }).email).not.toBeUndefined()
+    expect(validate({ email: 'mysite@.org.org' }).email).not.toBeUndefined()
+    expect(validate({ email: '.mysite@mysite.org' }).email).not.toBeUndefined()
+    expect(validate({ email: 'mysite()*@gmail.com' }).email).not.toBeUndefined()
+    expect(
+      validate({ email: 'mysite..1234@yahoo.com' }).email,
+    ).not.toBeUndefined()
   })
 })
 
@@ -78,6 +88,6 @@ describe('<ContactInfoForm />', () => {
 
     await wait(0) // Wait for promises to resolve
 
-    expect(submitMock).toHaveBeenCalledTimes(1)
+    expect(submitMock).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
Fixes #1874(issue)
# Description
add more email validation for contactInfo page to avoid input invalid email address 
> Please include a summary of the change.

# Checklist:
- [x ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ x] I have added a comment to any confusing code
