### PR TITLE
Changing log from error to info

### DIFF
--- a/f2/server.js
+++ b/f2/server.js
@@ -110,7 +110,7 @@ const uploadData = async (req, res, fields, files) => {
 app.get('/', async function (req, res, next) {
   availableData.numberOfSubmissions = await getReportCount()
   if (availableData.numberOfSubmissions >= process.env.SUBMISSIONS_PER_DAY) {
-    console.warn('Warning: redirecting request to CAFC')
+    console.log('Warning: redirecting request to CAFC')
     res.redirect(
       req.subdomains.includes('signalement')
         ? 'https://www.antifraudcentre-centreantifraude.ca/report-signalez-fra.htm'


### PR DESCRIPTION

# Description

> In Node `console.info()` is an alias for `console.log()` and both of these will write to stdout.  When entries from stdout get absorbed into Azure they are recorded as Informational records in Log Analytics. 

> Additionally, `console.warn()` is an alias for `console.error()` and both of these will write to stderr.  When entries from stderr get absorbed into Azure they are recorded as Error records in Log Analytics.

> In this case, I wanted to change this log line from being an Error to being Information.

# Further Improvements

> In the future we could write to the log analytics workspace API and choose from a number of log categories.  https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs#overview

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)

