### PR TITLE
add warning message in email subject if self harm words detected

### DIFF
--- a/f2/src/utils/encryptedEmail.js
+++ b/f2/src/utils/encryptedEmail.js
@@ -51,11 +51,14 @@ const getEmailWarning = (data) =>
     ? ': WARNING: potential offensive image'
     : ''
 
+const getSelfHarmWord = (data) =>
+  data.selfHarmWords.length ? ': WARNING: self harm words detected' : ''
+
 const encryptMessage = (uid, emailAddress, message, data, sendMail) => {
   const openssl = 'openssl smime -des3 -encrypt'
   const messageFile = `message_${nanoid()}.txt`
   const encryptedFile = messageFile + '.encrypted'
-  const subjectSuffix = getEmailWarning(data)
+  const subjectSuffix = getEmailWarning(data) + getSelfHarmWord(data)
 
   fs.writeFile(messageFile, message, function (err) {
     if (err) throw err
@@ -120,13 +123,13 @@ const encryptAndSend = async (uidList, emailList, data, message) => {
     })
   } else if (process.env.MAIL_LOCAL) {
     console.warn('Encrypted Mail: No certs to encrypt with!')
-    const subjectSuffix = getEmailWarning(data)
+    const subjectSuffix = getEmailWarning(data) + getSelfHarmWord(data)
     prepareUnencryptedReportEmail(message, data, (m) =>
       sendMail(process.env.MAIL_LOCAL, m, data.reportId, subjectSuffix),
     )
   } else {
     console.warn('Encrypted Mail: No certs to encrypt with!')
-    const subjectSuffix = getEmailWarning(data)
+    const subjectSuffix = getEmailWarning(data) + getSelfHarmWord(data)
     prepareUnencryptedReportEmail(message, data, (m) =>
       sendMail(data.contactInfo.email, m, data.reportId, subjectSuffix),
     )


### PR DESCRIPTION
Fixes #1910(issue)

# Description
when victim input self harm words in the report, the analyst's email will have a
warning message" WARNING: self harm words detected" in subject line for easily tracking


# Checklist:

- [ x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
