### PR TITLE
Should "Report Language" be displayed full word in analyst mail

### DIFF
--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -26,13 +26,14 @@ const formatReportInfo = (data) => {
     data.anonymous.anonymousOptions.length > 0
       ? data.anonymous.anonymousOptions[0].replace('anonymousPage.', '')
       : 'no'
+  let reportLanguage = data.language === 'en' ? 'English' : 'French'
 
   returnString +=
     '<h2>Report Information</h2>' +
     formatTable(
       formatLineHtml('Report number:', data.reportId) +
         formatLineHtml('Date received:', data.submissionTime) +
-        formatLineHtml('Report language:', data.language) +
+        formatLineHtml('Report language:', reportLanguage) +
         formatLineHtml('Report version:', data.prodVersion) +
         formatLineHtml('Anonymous report:', isAnonymous) +
         formatLineHtml('Flagged:', selfHarmString),


### PR DESCRIPTION
Fixes #1855

# Description

> The "Report Language" should be displayed "English or French" instead of "en or fr" in analyst mail

# Any new packages installed?

> no

# Required followup work

> 

# Checklist:

- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
