### PR TITLE
Trust unsigned TLS certs - shocking title, dont worry

### DIFF
--- a/f2/src/utils/submitReportToServer.js
+++ b/f2/src/utils/submitReportToServer.js
@@ -4,6 +4,9 @@ const fetch = require('isomorphic-fetch')
 const FormData = require('form-data')
 const { formDefaults } = require('../forms/defaultValues')
 
+// trust all TLS certs - not advised
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0
+
 async function submitReportToServer(url = '', data = {}) {
   const flattenedData = flatten(data, { safe: true })
   console.log(flattenedData)


### PR DESCRIPTION
The TLS certs used by RCMP for con.rcmp-grc.gc.ca are missing the intermediate cert in the chain (mistake). 👎 
It was quicker to make this utility trust all TLS certs instead of fixing the TLS cert at this time.

Fixes #1868 

# Description

> Please include a summary of the change.

# Any new packages installed?

> No

# Required followup work

> Fix the certificates by rebuilding them and re-installing them into the WAF :(

# Checklist:

- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
- [x] I have added documentation to any modified front-end code. (Or added missing documentation)
