### PR TITLE
redirect user to consent page if user cancel a report in half way

### DIFF
--- a/f2/src/AnonymousPage.js
+++ b/f2/src/AnonymousPage.js
@@ -10,18 +10,10 @@ import { BackButton } from './components/backbutton'
 import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 import { Page } from './components/Page'
-import { useHistory } from 'react-router-dom'
-import { useEffect } from 'react'
 
 export const AnonymousPage = () => {
   const [state, dispatch] = useStateValue()
   const { doneForms } = state
-  const history = useHistory()
-  useEffect(() => {
-    if (state.formData.consent.consentOptions.length === 0) {
-      history.push('/privacyconsent')
-    }
-  }, [history, state.formData.consent.consentOptions.length])
 
   return (
     <Route

--- a/f2/src/BusinessPage.js
+++ b/f2/src/BusinessPage.js
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import { useEffect } from 'react'
 import { jsx } from '@emotion/core'
 import { Route } from 'react-router-dom'
 import { Trans } from '@lingui/macro'
@@ -12,7 +11,6 @@ import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 import { nextWhatWasAffectedUrl } from './utils/nextWhatWasAffectedUrl'
 import { Page } from './components/Page'
-import { useHistory } from 'react-router-dom'
 
 export const BusinessPage = () => {
   const [state, dispatch] = useStateValue()
@@ -20,12 +18,6 @@ export const BusinessPage = () => {
   const affectedOptions = formData.whatWasAffected
     ? formData.whatWasAffected.affectedOptions
     : []
-  const history = useHistory()
-  useEffect(() => {
-    if (state.formData.consent.consentOptions.length === 0) {
-      history.push('/privacyconsent')
-    }
-  }, [history, state.formData.consent.consentOptions.length])
 
   return (
     <Route

--- a/f2/src/ContactInfoPage.js
+++ b/f2/src/ContactInfoPage.js
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import { useEffect } from 'react'
 import { jsx } from '@emotion/core'
 import { Route } from 'react-router-dom'
 import { Trans } from '@lingui/macro'
@@ -11,17 +10,9 @@ import { BackButton } from './components/backbutton'
 import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 import { Page } from './components/Page'
-import { useHistory } from 'react-router-dom'
 
 export const ContactInfoPage = () => {
-  const [state, dispatch] = useStateValue()
-  const history = useHistory()
-  useEffect(() => {
-    if (state.formData.consent.consentOptions.length === 0) {
-      history.push('/privacyconsent')
-    }
-  }, [history, state.formData.consent.consentOptions.length])
-
+  const [, dispatch] = useStateValue()
   return (
     <Route
       render={({ history }) => (

--- a/f2/src/DevicesPage.js
+++ b/f2/src/DevicesPage.js
@@ -1,5 +1,5 @@
 import { Route } from 'react-router-dom'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Trans } from '@lingui/macro'
 import { H1 } from './components/header'
 import { P } from './components/paragraph'
@@ -10,7 +10,6 @@ import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 import { nextWhatWasAffectedUrl } from './utils/nextWhatWasAffectedUrl'
 import { Page } from './components/Page'
-import { useHistory } from 'react-router-dom'
 
 export const DevicesPage = () => {
   const [state, dispatch] = useStateValue()
@@ -18,12 +17,6 @@ export const DevicesPage = () => {
   const affectedOptions = formData.whatWasAffected
     ? formData.whatWasAffected.affectedOptions
     : []
-  const history = useHistory()
-  useEffect(() => {
-    if (state.formData.consent.consentOptions.length === 0) {
-      history.push('/privacyconsent')
-    }
-  }, [history, state.formData.consent.consentOptions.length])
 
   return (
     <Route

--- a/f2/src/EvidencePage.js
+++ b/f2/src/EvidencePage.js
@@ -12,15 +12,10 @@ import { BackButton } from './components/backbutton'
 import { Stack, Box } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 import { Page } from './components/Page'
-import { useHistory } from 'react-router-dom'
 
 export const EvidencePage = () => {
-  const [state, dispatch] = useStateValue()
-  const { doneForms } = state
-  const history = useHistory()
-  if (state.formData.consent.consentOptions.length === 0) {
-    history.push('/privacyconsent')
-  }
+  const [data, dispatch] = useStateValue()
+  const { doneForms } = data
 
   return (
     <Route

--- a/f2/src/Home.js
+++ b/f2/src/Home.js
@@ -51,45 +51,45 @@ export const Home = () => (
       <Route path="/termsandconditions">
         <TermsAndConditions />
       </Route>
-      <Route path="/howdiditstart">
+      <RedirectRoute path="/howdiditstart">
         <HowDidItStartPage />
-      </Route>
-      <Route path="/whatwasaffected">
+      </RedirectRoute>
+      <RedirectRoute path="/whatwasaffected">
         <WhatWasAffectedPage />
-      </Route>
-      <Route path="/moneylost">
+      </RedirectRoute>
+      <RedirectRoute path="/moneylost">
         <MoneyLostPage />
-      </Route>
-      <Route path="/information">
+      </RedirectRoute>
+      <RedirectRoute path="/information">
         <InformationPage />
-      </Route>
-      <Route path="/devices">
+      </RedirectRoute>
+      <RedirectRoute path="/devices">
         <DevicesPage />
-      </Route>
-      <Route path="/business">
+      </RedirectRoute>
+      <RedirectRoute path="/business">
         <BusinessPage />
-      </Route>
-      <Route path="/whathappened">
+      </RedirectRoute>
+      <RedirectRoute path="/whathappened">
         <WhatHappenedPage />
-      </Route>
+      </RedirectRoute>
       <RedirectRoute path="/suspectclues">
         <SuspectCluesPage />
       </RedirectRoute>
-      <Route path="/evidence">
+      <RedirectRoute path="/evidence">
         <EvidencePage />
-      </Route>
-      <Route path="/location">
+      </RedirectRoute>
+      <RedirectRoute path="/location">
         <LocationPage />
-      </Route>
+      </RedirectRoute>
       <Route path="/anonymous">
         <AnonymousPage />
       </Route>
-      <Route path="/contactinfo">
+      <RedirectRoute path="/contactinfo">
         <ContactInfoPage />
-      </Route>
-      <Route path="/confirmation">
+      </RedirectRoute>
+      <RedirectRoute path="/confirmation">
         <ConfirmationPage />
-      </Route>
+      </RedirectRoute>
       <Route exact path="/thankYouPage">
         <ThankYouPage />
       </Route>
@@ -105,9 +105,9 @@ export const Home = () => (
       <Route path="/finalFeedbackThanks">
         <FinalFeedbackThanksPage />
       </Route>
-      <Route path="/locationAnonymous">
+      <RedirectRoute path="/locationAnonymous">
         <LocationAnonymousPage />
-      </Route>
+      </RedirectRoute>
 
       <Route>
         <PageNotFound />

--- a/f2/src/HowDidItStartPage.js
+++ b/f2/src/HowDidItStartPage.js
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import { useEffect } from 'react'
 import { jsx } from '@emotion/core'
 import { Route } from 'react-router-dom'
 import { Trans } from '@lingui/macro'
@@ -11,17 +10,10 @@ import { BackButton } from './components/backbutton'
 import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 import { Page } from './components/Page'
-import { useHistory } from 'react-router-dom'
 
 export const HowDidItStartPage = () => {
-  const [state, dispatch] = useStateValue()
-  const { doneForms } = state
-  const history = useHistory()
-  useEffect(() => {
-    if (state.formData.consent.consentOptions.length === 0) {
-      history.push('/privacyconsent')
-    }
-  })
+  const [data, dispatch] = useStateValue()
+  const { doneForms } = data
 
   return (
     <Route

--- a/f2/src/InformationPage.js
+++ b/f2/src/InformationPage.js
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import { useEffect } from 'react'
 import { jsx } from '@emotion/core'
 import { Route } from 'react-router-dom'
 import { Trans } from '@lingui/macro'
@@ -12,7 +11,6 @@ import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 import { nextWhatWasAffectedUrl } from './utils/nextWhatWasAffectedUrl'
 import { Page } from './components/Page'
-import { useHistory } from 'react-router-dom'
 
 export const InformationPage = () => {
   const [state, dispatch] = useStateValue()
@@ -20,12 +18,6 @@ export const InformationPage = () => {
   const affectedOptions = formData.whatWasAffected
     ? formData.whatWasAffected.affectedOptions
     : []
-  const history = useHistory()
-  useEffect(() => {
-    if (state.formData.consent.consentOptions.length === 0) {
-      history.push('/privacyconsent')
-    }
-  }, [history, state.formData.consent.consentOptions.length])
 
   return (
     <Route

--- a/f2/src/LocationAnonymousPage.js
+++ b/f2/src/LocationAnonymousPage.js
@@ -1,5 +1,5 @@
 import { Route } from 'react-router-dom'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Trans } from '@lingui/macro'
 import { H1 } from './components/header'
 import { Lead } from './components/paragraph'
@@ -9,17 +9,10 @@ import { BackButton } from './components/backbutton'
 import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 import { Page } from './components/Page'
-import { useHistory } from 'react-router-dom'
 
 export const LocationAnonymousPage = () => {
-  const [state, dispatch] = useStateValue()
-  const { doneForms } = state
-  const history = useHistory()
-  useEffect(() => {
-    if (state.formData.consent.consentOptions.length === 0) {
-      history.push('/privacyconsent')
-    }
-  }, [history, state.formData.consent.consentOptions.length])
+  const [data, dispatch] = useStateValue()
+  const { doneForms } = data
 
   return (
     <Route

--- a/f2/src/LocationPage.js
+++ b/f2/src/LocationPage.js
@@ -1,5 +1,5 @@
 import { Route } from 'react-router-dom'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Trans } from '@lingui/macro'
 import { H1 } from './components/header'
 import { Lead } from './components/paragraph'
@@ -12,21 +12,14 @@ import { useStateValue } from './utils/state'
 import { formatPostalCode } from './utils/formatPostalCode'
 import { Page } from './components/Page'
 import { formDefaults } from './forms/defaultValues'
-import { useHistory } from 'react-router-dom'
 
 export const LocationPage = () => {
-  const [state, dispatch] = useStateValue()
-  const { doneForms } = state
+  const [data, dispatch] = useStateValue()
+  const { doneForms } = data
   const formData = {
     ...formDefaults,
-    ...state.formData,
+    ...data.formData,
   }
-  const history = useHistory()
-  useEffect(() => {
-    if (state.formData.consent.consentOptions.length === 0) {
-      history.push('/privacyconsent')
-    }
-  }, [history, state.formData.consent.consentOptions.length])
 
   return (
     <Route

--- a/f2/src/MoneyLostPage.js
+++ b/f2/src/MoneyLostPage.js
@@ -10,7 +10,6 @@ import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 import { nextWhatWasAffectedUrl } from './utils/nextWhatWasAffectedUrl'
 import { Page } from './components/Page'
-import { useHistory } from 'react-router-dom'
 
 export const MoneyLostPage = () => {
   const [state, dispatch] = useStateValue()
@@ -18,10 +17,6 @@ export const MoneyLostPage = () => {
   const affectedOptions = formData.whatWasAffected
     ? formData.whatWasAffected.affectedOptions
     : []
-  const history = useHistory()
-  if (state.formData.consent.consentOptions.length === 0) {
-    history.push('/privacyconsent')
-  }
 
   return (
     <Route

--- a/f2/src/WhatHappenedPage.js
+++ b/f2/src/WhatHappenedPage.js
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import { useEffect } from 'react'
 import { jsx } from '@emotion/core'
 import { Route } from 'react-router-dom'
 import { Trans } from '@lingui/macro'
@@ -14,22 +13,15 @@ import { useStateValue } from './utils/state'
 import { Page } from './components/Page'
 import { Li } from './components/list-item'
 import { formDefaults } from './forms/defaultValues'
-import { useHistory } from 'react-router-dom'
 
 export const WhatHappenedPage = () => {
-  const [state, dispatch] = useStateValue()
-  const { doneForms } = state
+  const [data, dispatch] = useStateValue()
+  const { doneForms } = data
 
   const whatWasAffected = {
     ...formDefaults.whatWasAffected,
-    ...state.formData.whatWasAffected,
+    ...data.formData.whatWasAffected,
   }
-  const history = useHistory()
-  useEffect(() => {
-    if (state.formData.consent.consentOptions.length === 0) {
-      history.push('/privacyconsent')
-    }
-  }, [history, state.formData.consent.consentOptions.length])
 
   return (
     <Route

--- a/f2/src/WhatWasAffected.js
+++ b/f2/src/WhatWasAffected.js
@@ -1,5 +1,5 @@
 import { Route } from 'react-router-dom'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Trans } from '@lingui/macro'
 import { H1 } from './components/header'
 import { Lead } from './components/paragraph'
@@ -10,17 +10,10 @@ import { Stack } from '@chakra-ui/core'
 import { useStateValue } from './utils/state'
 import { nextWhatWasAffectedUrl } from './utils/nextWhatWasAffectedUrl'
 import { Page } from './components/Page'
-import { useHistory } from 'react-router-dom'
 
 export const WhatWasAffectedPage = () => {
-  const [state, dispatch] = useStateValue()
-  const { doneForms } = state
-  const history = useHistory()
-  useEffect(() => {
-    if (state.formData.consent.consentOptions.length === 0) {
-      history.push('/privacyconsent')
-    }
-  }, [history, state.formData.consent.consentOptions.length])
+  const [data, dispatch] = useStateValue()
+  const { doneForms } = data
 
   return (
     <Route


### PR DESCRIPTION
This PR  redirect the user back to the consent page if user cancel a report and then use back button  go back to the report flow.

Fixes #1934 #1925(issue)

# Description
before this PR : if user cancel a report and then use back button , user will go back to the report flow. This PR redirect the user back to the consent page by using  route component,  Also, delete unneeded code, make code easier to maintenance. 

# Any new packages installed?
No

> Is there anything related to this that still needs to be done (ex: documentation changes).
No
# Checklist:

- [ x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
