### PR TITLE
privacy consent page should be recorded as the other page

### DIFF
--- a/f2/src/forms/PrivacyConsentInfoForm.js
+++ b/f2/src/forms/PrivacyConsentInfoForm.js
@@ -10,6 +10,7 @@ import { CheckboxAdapter } from '../components/checkbox'
 import { FormArrayControl } from '../components/FormArrayControl'
 import { useLingui } from '@lingui/react'
 import { ErrorSummary } from '../components/ErrorSummary'
+import { formDefaults } from './defaultValues'
 
 const validate = (values) => {
   const errors = {}
@@ -25,8 +26,8 @@ export const PrivacyConsentInfoForm = (props) => {
   const { i18n } = useLingui()
   const [data] = useStateValue()
   const whetherConsent = {
-    consentOptions: [],
-    ...data.formData.whetherConsent,
+    ...formDefaults.consent,
+    ...data.formData.consent,
   }
   const consentOptions = ['privacyConsentInfoForm.yes']
 


### PR DESCRIPTION
Fixes #1929

# Description

> When you click consent on privacy page, go to the next page and then click on go back button. This check on privacy consent is not saved like the info on the other pages are saved.

# Any new packages installed?

> no

# Required followup work

> no

# Checklist:

- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
