### PR TITLE
form flow fix when cancelled at summary page

### DIFF
--- a/f2/src/AnonymousPage.js
+++ b/f2/src/AnonymousPage.js
@@ -28,7 +28,6 @@ export const AnonymousPage = () => {
               <Lead>
                 <Trans id="anonymousPage.intro" />
               </Lead>
-              {console.log(doneForms)}
               <AnonymousInfoForm
                 onSubmit={(data) => {
                   dispatch({

--- a/f2/src/utils/state.js
+++ b/f2/src/utils/state.js
@@ -31,6 +31,7 @@ export const reducer = (state, action) => {
       return {
         ...state,
         formData: { ...initialState.formData },
+        doneForms: false,
         submitted: false,
         reportId: undefined,
       }


### PR DESCRIPTION
Fixes #1954

# Description

> Part one: If the user cancels at summary page and use the back arrow key to go back to the previous pages, it will take the user to your privacy page. ---> That's good

Part two: From the privacy page, the user clicks on consent and press continue to go to Report Anonymously page. AT this page, the user clicks on Continue button to go to the next page and here is the issue

Actual Result: The next page is "Review your report" page
Expected Result: The next page should be "How did the incident start?" page

# Any new packages installed?

> no

# Required followup work

> no

# Checklist:

- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
- [x] I have added documentation to any modified front-end code. (Or added missing documentation)
