### PR TITLE
Stop Colorizing WinstonExpress

### DIFF
--- a/f2/server.js
+++ b/f2/server.js
@@ -88,7 +88,6 @@ app
     expressWinston.logger({
       transports: [new winston.transports.Console()],
       format: winston.format.combine(
-        winston.format.colorize(),
         winston.format.json(),
       ),
       meta: true, // optional: control whether you want to log the meta data about the request (default to true)


### PR DESCRIPTION
# Description
The Winston-Express config was mistakenly colorizing the records.  There was a setting which was overriding our desire to not colourize.

> I removed the line and tested the updated code and I can see that the colourizing characters in question have been removed.

# Testing

> Take master branch and Run the server locally and visit localhost:3000.  Then look at the server logging, and after formatting the JSON logging you will see that the "level" attribute is displayed with extra colorizing characters.

> Then, take this branch and do the same test and you will see that those characters have been removed.

# Evidence of Before / After:
<img width="604" alt="After" src="https://user-images.githubusercontent.com/51758091/83789706-199f4f00-a665-11ea-90c5-5c4d0fa7c5d5.png">
![before](https://user-images.githubusercontent.com/51758091/83790028-8fa3b600-a665-11ea-9ace-d614c2d9cf3c.png)




