### PR TITLE
Click on any link in cancellation page should be open a new page

### DIFF
--- a/f2/src/CancelPage.js
+++ b/f2/src/CancelPage.js
@@ -63,6 +63,7 @@ export const CancelPage = () => {
                       ? 'https://www.getcybersafe.gc.ca/index-en.aspx'
                       : 'https://www.pensezcybersecurite.gc.ca/index-fr.aspx'
                   }
+                  isExternal
                 >
                   <Trans id="thankYouPage.helpResource1" />
                 </A>
@@ -74,6 +75,7 @@ export const CancelPage = () => {
                       ? 'http://www.antifraudcentre.ca/index-eng.htm'
                       : 'http://www.antifraudcentre.ca/index-fra.htm'
                   }
+                  isExternal
                 >
                   <Trans id="thankYouPage.helpResource2" />
                 </A>
@@ -85,6 +87,7 @@ export const CancelPage = () => {
                       ? 'http://www.rcmp-grc.gc.ca/to-ot/tis-set/cyber-tips-conseils-eng.htm'
                       : 'http://www.rcmp-grc.gc.ca/to-ot/tis-set/cyber-tips-conseils-fra.htm'
                   }
+                  isExternal
                 >
                   <Trans id="thankYouPage.helpResource3" />
                 </A>


### PR DESCRIPTION
Fixes #1986

# Description

> To be consistent, when the user clicks on any links in the cancellation page, a new page should be opened. Currently, it overrides the current page

Additional quote from Hong "I think we are good with Tell us more and Create a new report. When the user clicks on "Create a new report", it will use the same tab. In this way, it will not confuse the users. "Tell us more" will use the same tab as well but it will be bring back the thank you page when the user hit the submit button on the feedback. I think it is good too"

# Any new packages installed?

> no

# Required followup work

> no

# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
