### PR TITLE
only USE getFileExtension function in the app. remove other functions to extract the extension of a file

### DIFF
--- a/f2/src/utils/acceptableFiles.js
+++ b/f2/src/utils/acceptableFiles.js
@@ -1,12 +1,10 @@
+const { getFileExtension } = require('./filenameUtils')
 const acceptableExtensions = '.png, .jpg, .jpeg, .doc, .docx, .xls, .xlsx, .pdf, .txt, .rtf'
   .split(',')
   .map((ext) => ext.trim())
 
-const getExtension = (fileName) =>
-  fileName.includes('.') ? fileName.split('.').pop().toLowerCase() : ''
-
 const fileExtensionPasses = (fileName) => {
-  return acceptableExtensions.indexOf('.' + getExtension(fileName)) > -1
+  return acceptableExtensions.indexOf('.' + getFileExtension(fileName)) > -1
 }
 
 const fileSizePasses = (fileSize) => fileSize > 0 && fileSize <= 4 * 1024 * 1024


### PR DESCRIPTION

Fixes #2019( issue)

# Description
The application currently has multiple functions that serve the same purpose. Issues like this make the app harder to maintain and causes unexpected outcomes. 

> Please include a summary of the change.

The PR  refactor the project to ensure only getFileExtension function in use to extract the extension of a file. 


# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [ x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
