### PR TITLE
If a user enters an invalid postal code, the report to the analyst is malformed. 

### DIFF
--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -70,11 +70,14 @@ const formatVictimDetails = (data) => {
       postalCity = 'Location lookup is not found'
       postalProv = 'Location lookup is not found'
     } else {
-      postalCity = zipcodes.lookup(data.location.postalCode).city
-      postalProv = zipcodes.lookup(data.location.postalCode).state
+      postalCity = location.city
+      postalProv = location.state
     }
   } catch (error) {
-    console.log(error)
+    //logging
+    console.error(error)
+    postalCity = 'Location lookup failed'
+    postalProv = 'Location lookup failed'
   }
 
   const rows =

--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -64,10 +64,17 @@ const formatVictimDetails = (data) => {
 
   let postalCity = ''
   let postalProv = ''
-
-  if (data.location.postalCode) {
-    postalCity = zipcodes.lookup(data.location.postalCode).city
-    postalProv = zipcodes.lookup(data.location.postalCode).state
+  try {
+    let location = zipcodes.lookup(data.location.postalCode)
+    if (location === undefined) {
+      postalCity = 'Location lookup is not found'
+      postalProv = 'Location lookup is not found'
+    } else {
+      postalCity = zipcodes.lookup(data.location.postalCode).city
+      postalProv = zipcodes.lookup(data.location.postalCode).state
+    }
+  } catch (error) {
+    console.log(error)
   }
 
   const rows =


### PR DESCRIPTION
Fixes #2032

# Description

> If a user enters a postal code in correct format (B1B1B1 B2B2B2) but not actually in the Canadian Postal Code lookup, this will produce an error when creating the e-mail for the analyst:

ERROR in formatAnalystEmail (report NCFRS-p7n6cwadgea): TypeError: Cannot read property 'city' of undefined

The solution:

For a hot fix: We should initialize to blank strings if the postal code lookup comes back with nothing

However long term: Validate that the postal code actually exists and display a message to user.

# Any new packages installed?

> Give details

# Required followup work

> Is there anything related to this that still needs to be done (ex: documentation changes).

# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
