### PR TITLE
Analyst Report Suspect Header Error

### DIFF
--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -449,7 +449,7 @@
   "whenDidItHappenPage.dateRange.end.label": "When did it last happen?",
   "whenDidItHappenPage.dateRange.start.label": "When did it start?",
   "whenDidItHappenPage.intro": "These incidents can happen once or multiple times. Tell us how often the suspect tried to contact you.",
-  "whenDidItHappenPage.nextPage": "Next: What do you think could be affected?", 
+  "whenDidItHappenPage.nextPage": "Next: What do you think could be affected?",
   "whenDidItHappenPage.notSure.helperText": "Enter the time frame that the suspect tried to contact you, to the best of your memory.",
   "whenDidItHappenPage.notSure.label": "Describe the series of events.",
   "whenDidItHappenPage.options.moreThanOnce": "More than once",

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -449,7 +449,7 @@
   "whenDidItHappenPage.dateRange.end.label": "Quand est-ce arrivé pour la dernière fois?",
   "whenDidItHappenPage.dateRange.start.label": "Quand est-ce arrivé pour la première fois?",
   "whenDidItHappenPage.intro": "Ce type d’incident peut se produire une fois ou plusieurs fois. Dites-nous à quelle fréquence le suspect a essayé de vous contacter.",
-  "whenDidItHappenPage.nextPage": "Étape suivante : D’après vous, quelles pourraient être les répercussions?",  
+  "whenDidItHappenPage.nextPage": "Étape suivante : D’après vous, quelles pourraient être les répercussions?",
   "whenDidItHappenPage.notSure.helperText": "Indiquez du mieux que vous pouvez la période pendant laquelle le suspect a essayé de communiquer avec vous.",
   "whenDidItHappenPage.notSure.label": "Décrivez les événements.",
   "whenDidItHappenPage.options.moreThanOnce": "Plusieurs fois",

--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -251,7 +251,7 @@ const formatNarrative = (data) => {
       data.moneyLost.demandedMoney,
     ) +
     formatLineHtml(
-      lang['confirmationPage.personalInformation.typeOfInfoObtained'],
+      lang['confirmationPage.personalInformation.typeOfInfoReq'],
       infoReqString,
     ) +
     formatLineHtml(


### PR DESCRIPTION
Fixes #2125

# Description

> According to the questions asked on the current website, the new analyst reports should indicate "Information requested by the suspect" and "Information obtained by the suspect".
# Any new packages installed?

> no

# Required followup work

> no

# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
