### PR TITLE
delete field since it already added to analyst email template

### DIFF
--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -475,18 +475,16 @@
   "whenDidItStart.startDay": "Day",
   "whenDidItStart.startMonth": "Month",
   "whenDidItStart.startYear": "Year",
-  "whoAreYouReportForPage.details": "Details",
   "whoAreYouReportForPage.business.helperText": "Provide a business name, a website and/or some way to contact the business",
   "whoAreYouReportForPage.business.label": "What business are you reporting for?",
+  "whoAreYouReportForPage.details": "Details",
   "whoAreYouReportForPage.nextButton": "Continue",
   "whoAreYouReportForPage.nextPage": "Next: How did the incident start?",
-  "whoAreYouReportForPage.someone.label": "Who are you reporting for?",
-  "whoAreYouReportForPage.someone.helperText": "Tell us your relationship to them, and their full name",
   "whoAreYouReportForPage.options.business": "A business",
-  "whoAreYouReportForPage.options.myself": "Myself",  
+  "whoAreYouReportForPage.options.myself": "Myself",
   "whoAreYouReportForPage.options.someone": "Someone I know",
   "whoAreYouReportForPage.or": "or",
+  "whoAreYouReportForPage.someone.helperText": "Tell us your relationship to them, and their full name",
+  "whoAreYouReportForPage.someone.label": "Who are you reporting for?",
   "whoAreYouReportForPage.title": "Who are you reporting for?"
-
-
 }

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -475,17 +475,16 @@
   "whenDidItStart.startDay": "Jour",
   "whenDidItStart.startMonth": "Mois",
   "whenDidItStart.startYear": "Année",
-  "whoAreYouReportForPage.details": "Détails",
   "whoAreYouReportForPage.business.helperText": "Fournissez un nom d’entreprise, un site Web ou une autre façon de contacter cette entreprise.",
   "whoAreYouReportForPage.business.label": "Pour quelle entreprise faites-vous un signalement?",
+  "whoAreYouReportForPage.details": "Détails",
   "whoAreYouReportForPage.nextButton": "Continuer",
   "whoAreYouReportForPage.nextPage": "Étape suivante : Comment l’incident a-t-il commencé?",
-  "whoAreYouReportForPage.someone.label": "Pour qui faites-vous le signalement?",
-  "whoAreYouReportForPage.someone.helperText": "Dites-nous quelle est votre relation par rapport à cette personne, et dites-nous son nom complet.",
   "whoAreYouReportForPage.options.business": "Une entreprise",
-  "whoAreYouReportForPage.options.myself": "Moi-même",  
+  "whoAreYouReportForPage.options.myself": "Moi-même",
   "whoAreYouReportForPage.options.someone": "Une connaissance",
   "whoAreYouReportForPage.or": "ou",
+  "whoAreYouReportForPage.someone.helperText": "Dites-nous quelle est votre relation par rapport à cette personne, et dites-nous son nom complet.",
+  "whoAreYouReportForPage.someone.label": "Pour qui faites-vous le signalement?",
   "whoAreYouReportForPage.title": "Pour qui faites-vous le signalement?"
-
 }

--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -128,9 +128,18 @@ const formatVictimDetails = (data) => {
     formatLineHtml(lang['locationinfoPage.postalCity'], postalCity) +
     formatLineHtml(lang['locationinfoPage.postalProv'], postalProv) +
     formatLineHtml(lang['privacyConsentInfoForm.consent'], consentString) +
-    formatLineHtml(lang['whoAreYouReportForPage.title'], lang[data.whoAreYouReportFor.whoYouReportFor]) +
-    formatLineHtml(lang['whoAreYouReportForPage.details'], data.whoAreYouReportFor.someoneDescription) +
-    formatLineHtml(lang['whoAreYouReportForPage.details'], data.whoAreYouReportFor.businessDescription)  
+    formatLineHtml(
+      lang['whoAreYouReportForPage.title'],
+      lang[data.whoAreYouReportFor.whoYouReportFor],
+    ) +
+    formatLineHtml(
+      lang['whoAreYouReportForPage.details'],
+      data.whoAreYouReportFor.someoneDescription,
+    ) +
+    formatLineHtml(
+      lang['whoAreYouReportForPage.details'],
+      data.whoAreYouReportFor.businessDescription,
+    )
 
   delete data.contactInfo.fullName
   delete data.contactInfo.email
@@ -219,6 +228,17 @@ const formatIncidentInformation = (data) => {
   delete data.howdiditstart.startMonth
   delete data.howdiditstart.startYear
   delete data.howdiditstart.howManyTimes
+  delete data.whenDidItHappen.happenedOnceDay
+  delete data.whenDidItHappen.happenedOnceMonth
+  delete data.whenDidItHappen.happenedOnceYear
+  delete data.whenDidItHappen.startDay
+  delete data.whenDidItHappen.startMonth
+  delete data.whenDidItHappen.startYear
+  delete data.whenDidItHappen.endDay
+  delete data.whenDidItHappen.endMonth
+  delete data.whenDidItHappen.endYear
+  delete data.whenDidItHappen.incidentFrequency
+  delete data.whenDidItHappen.description
   delete data.howdiditstart.howDidTheyReachYou
   delete data.whatWasAffected.affectedOptions
   return formatSection(lang['howDidItStartPage.incidentInformation'], rows)


### PR DESCRIPTION
Fixes #2128(issue)

# Description
d delete the fields since it already added to analyst email template to avoid the field show up at the button of the analyst email. This PR also reorder the the en.json and fr.json. the hook has formatted the code so it show adding new line in FormatAnalystEmail.js .
> Please include a summary of the change.

# Any new packages installed?
no 
> Give details

# Required followup work

> Is there anything related to this that still needs to be done (ex: documentation changes).

# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [ x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
