### PR TITLE
Copy fix to this branch for extra space issue PR2166

### DIFF
--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -484,10 +484,7 @@ const formatSuspectDetails = (data) => {
 }
 
 const formatFinancialTransactions = (data) => {
-  const methods =
-    data.moneyLost.methodOther && data.moneyLost.methodOther.length > 0
-      ? data.moneyLost.methodPayment.concat([data.moneyLost.methodOther])
-      : data.moneyLost.methodPayment
+  const methods = data.moneyLost.methodPayment
 
   const origPaymentString = methods
     .filter((method) => method !== 'methodPayment.other')
@@ -495,6 +492,12 @@ const formatFinancialTransactions = (data) => {
     .join(', ')
 
   let paymentString = origPaymentString
+
+  paymentString =
+    data.moneyLost.methodOther && data.moneyLost.methodOther.length > 0
+      ? String(origPaymentString) + ', ' + [data.moneyLost.methodOther]
+      : String(origPaymentString)
+
   let languageAdjustedPaymentString = {
     'e transfer': lang['methodPayment.eTransfer'],
     eTransfer: lang['methodPayment.eTransfer'],
@@ -531,7 +534,7 @@ const formatFinancialTransactions = (data) => {
     ) +
     formatLineHtml(
       lang['confirmationPage.moneyLost.methodPayment'],
-      paymentString,
+      paymentString, //data.moneyLost.paymentString,  // methodOther,
     ) +
     formatLineHtml(
       lang['confirmationPage.moneyLost.transactionDate'],

--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -491,9 +491,7 @@ const formatFinancialTransactions = (data) => {
     .map((method) => unCamel(method.replace('methodPayment.', '')))
     .join(', ')
 
-  let paymentString = origPaymentString
-
-  paymentString =
+  let paymentString =
     data.moneyLost.methodOther && data.moneyLost.methodOther.length > 0
       ? String(origPaymentString) + ', ' + [data.moneyLost.methodOther]
       : String(origPaymentString)


### PR DESCRIPTION
Fixes #2166 

# Description
This is to fix the issue of extra spaces were injected to the type in of "other" in financial loss section, and forcefully turned to lower case when user type in any (like "BBBBB") in other, the report showed "b b b b b "

It was in other branch, however due to unexpected content shows up during rebase stage, create this branch to have a clean push.


What happened? | I WAS ASKED TO PAY $5000
-- | --
Amount of money asked for by suspect | 5555
Information asked for by suspect | credit card, dob, sin, CCCCCCCCCC, home address ===> "CCCCCC" 100% reserved
Amount of money stolen by suspect | 1111
Information obtained by suspect | credit card, dob, home address, sin, DDDDDDDDDDDD ==> 100% reserved
Suspect name | CRA
-- | --
Suspect email | we@gmail.com
Suspect phone number | (613) 111-1111
Suspect website | www.cnn.com
Application used by the suspect | MS OFFICE
Suspect address | His account
Other means | AAAAAAAAA ===> 100% reserved



> Please include a summary of the change.

const methods = data.moneyLost.methodPayment

  const paymentStringOrig = methods
    .filter((method) => method !== 'methodPayment.other')
    .map((method) => unCamel(method.replace('methodPayment.', '')))
    .join(', ')

  let paymentString =
    data.moneyLost.methodOther && data.moneyLost.methodOther.length > 0
      ? String(paymentStringOrig) + ', ' + [data.moneyLost.methodOther]
      : String(paymentStringOrig)


# Any new packages installed?

> Give details

# Required followup work

> Is there anything related to this that still needs to be done (ex: documentation changes).

# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [ X] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
