### PR TITLE
Extra English in final analyst French Report

### DIFF
--- a/f2/src/forms/EvidenceInfoForm.js
+++ b/f2/src/forms/EvidenceInfoForm.js
@@ -109,6 +109,8 @@ export const EvidenceInfoForm = (props) => {
           <Trans id="fileUpload.fileDescription" />
           <Trans id="fileUpload.fileSize" />
           <Trans id="fileUpload.CosmosDBFile" />
+          <Trans id="fileUpload.classification.title" />
+          <Trans id="fileUpload.classification.cannotscan" />
           <Trans id="fileUpload.malwareScan" />
           <Trans id="fileUpload.malwareScan.clean" />
           <Trans id="fileUpload.isAdult" />

--- a/f2/src/locales/en.json
+++ b/f2/src/locales/en.json
@@ -196,6 +196,8 @@
   "fileUpload.CosmosDBFile": "CosmosDB file",
   "fileUpload.added": "File added",
   "fileUpload.adultScore": "Adult score",
+  "fileUpload.classification.cannotscan": "Could not scan content",
+  "fileUpload.classification.title": "Image classification",
   "fileUpload.fileAttachment": "File attachments",
   "fileUpload.fileAttachment.offensivewarning": "Image may be offensive",
   "fileUpload.fileAttachment.offensivewarning.block": "Warning:",

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -196,6 +196,8 @@
   "fileUpload.CosmosDBFile": "Fichier CosmosDB",
   "fileUpload.added": "Fichier ajouté",
   "fileUpload.adultScore": "Score adulte",
+  "fileUpload.classification.cannotscan": "Impossible de scanner le contenu",
+  "fileUpload.classification.title": "Classification des images",
   "fileUpload.fileAttachment": "Pièces jointes aux fichiers",
   "fileUpload.fileAttachment.offensivewarning": "L'image peut être choquante",
   "fileUpload.fileAttachment.offensivewarning.block": "à Alerte:",

--- a/f2/src/utils/formatAnalystEmail.js
+++ b/f2/src/utils/formatAnalystEmail.js
@@ -562,7 +562,10 @@ const formatFileAttachments = (data) => {
 
       const moderatorString =
         file.adultClassificationScore === 'Could not scan'
-          ? formatLineHtml('Image classification:', 'Could not scan content')
+          ? formatLineHtml(
+              lang['fileUpload.classification.title'],
+              lang['fileUpload.classification.cannotscan'],
+            )
           : formatLineHtml(
               lang['fileUpload.isAdult'],
               file.isImageAdultClassified,
@@ -606,7 +609,9 @@ const formatFileAttachments = (data) => {
         formatLineHtml(lang['fileUpload.CosmosDBFile'], file.sha1) +
         formatLineHtml(
           lang['fileUpload.malwareScan'],
-          file.malwareIsClean ? 'Clean' : file.malwareScanDetail,
+          file.malwareIsClean
+            ? lang['fileUpload.malwareScan.clean']
+            : file.malwareScanDetail,
         ) +
         moderatorString +
         downloadLink


### PR DESCRIPTION
Fixes #2225 

# Description
In the file upload/scan section, there are 2 places still in English while user wrote French report.
One is "scan clean", the other one is "'Image classification:', 'Could not scan content'"


> Please include a summary of the change.
In the analyst report part and associated language definition and evidenceForm

# Any new packages installed?
No
> Give details

# Required followup work

> Is there anything related to this that still needs to be done (ex: documentation changes).

# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [ X] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
