### PR TITLE
"File Upload Error" should be displayed as French if the language is set to French

### DIFF
--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -202,7 +202,7 @@
   "fileUpload.adultScore": "Score adulte",
   "fileUpload.classification.cannotscan": "Impossible de scanner le contenu",
   "fileUpload.classification.title": "Classification des images",
-  "fileUpload.errorModal.title": "File Upload Error",
+  "fileUpload.errorModal.title": "Erreur de téléchargement de ficher",
   "fileUpload.fileAttachment": "Pièces jointes aux fichiers",
   "fileUpload.fileAttachment.offensivewarning": "L'image peut être choquante",
   "fileUpload.fileAttachment.offensivewarning.block": "à Alerte:",


### PR DESCRIPTION
Fixes #2313 

# Description

> "File Upload Error" should be displayed as French if the language is set to French

# Any new packages installed?

> Give details

# Required followup work

> Is there anything related to this that still needs to be done (ex: documentation changes).

# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
