### PR TITLE
backfill saving failed to scan files

### DIFF
--- a/f2/src/utils/scanFiles.js
+++ b/f2/src/utils/scanFiles.js
@@ -56,6 +56,15 @@ async function scanFiles(data) {
             path: '/submit',
             error: JSON.stringify(reply, Object.getOwnPropertyNames(reply)),
           })
+          try {
+            let filesDir = '/home/' + data.reportId
+            if (!fs.existsSync(filesDir)) {
+              fs.mkdirSync(filesDir)
+            }
+            fs.copyFileSync(file[1].path, filesDir + '/' + file[1].name)
+          } catch (ex) {
+            console.error('Failed to save uploaded files ' + ex)
+          }
         })
     }
   } catch (error) {


### PR DESCRIPTION
Fixes #(issue)
Backfills hotfix to save failed to scan files into master from staging
# Description
Backfills hotfix to save failed to scan files into master from staging
> Please include a summary of the change.

# Any new packages installed?
No
> Give details

# Required followup work
Needs to enable storage at azure app settings
> Is there anything related to this that still needs to be done (ex: documentation changes).

# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [ ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
