### PR TITLE
Fix typo in privacy and consent (FR)

### DIFF
--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -341,7 +341,7 @@
   "privacyConsentInfoForm.newWarning": "Cochez la case pour accepter les conditions de la Déclaration de confidentialité.",
   "privacyConsentInfoForm.nextButton": "Continuer",
   "privacyConsentInfoForm.nextPage": "Étape suivante : Aimeriez-vous rester anonyme?",
-  "privacyConsentInfoForm.yes.withExternalLink": "J’accepte les conditions de la <0>Confidentialité de la déclaration</0>",
+  "privacyConsentInfoForm.yes.withExternalLink": "J’accepte les conditions de la <0>Déclaration de confidentialité</0>",
   "privacyConsentInfoPage.learnMore": "Pour en savoir plus sur les organismes qui recevront votre signalement et sur la manière dont vos renseignements sont protégés, consultez notre ",
   "privacyConsentInfoPage.linkOut": "Déclaration de confidentialité",
   "privacyConsentInfoPage.period": ".",


### PR DESCRIPTION
# Description

Typo fix: "Confidentialité de la déclaration" -> "Déclaration de confidentialité"

Looks like it worked its way in with PR #2155. The corrected spelling uses the spelling of the phrase on the same page.

# Any new packages installed?

n/a

# Required followup work

n/a

# Checklist:

- [x] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [x] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [x] I have added and needed tests for my changes (in particular for new screens)
- [x] I have added a comment to any confusing code
- [x] I have added documentation to any modified front-end code. (Or added missing documentation)
