### PR TITLE
Fix French translation error in FYI button title change

### DIFF
--- a/f2/cypress/integration/common/home.js
+++ b/f2/cypress/integration/common/home.js
@@ -26,10 +26,10 @@ When('I change the language', () => {
   cy.contains('Commencer un rapport complet').first().click({ force: true })
 })
 
-When('I change the language and click Soumettre un renseignemen', () => {
+When('I change the language and click Soumettre un renseignement', () => {
   cy.contains('Français').first().click({ force: true })
   cy.wait(3000)
-  cy.contains('Soumettre un renseignemen').first().click({ force: true })
+  cy.contains('Soumettre un renseignement').first().click({ force: true })
 })
 
 // Second page - Before you start

--- a/f2/cypress/integration/generate_fyi_report_fr.feature
+++ b/f2/cypress/integration/generate_fyi_report_fr.feature
@@ -4,7 +4,7 @@ Feature: Test the entire report workflow in french
 
   Scenario: Home page
     Given I open the report home page
-    When I change the language and click Soumettre un renseignemen
+    When I change the language and click Soumettre un renseignement
     Then I click continue without checking consent
     Then "Cochez la case pour accepter les conditions de la Déclaration de confidentialité." should be shown
     When I check the consent checkbox

--- a/f2/src/locales/fr.json
+++ b/f2/src/locales/fr.json
@@ -279,7 +279,7 @@
   "informationPage.typeOfInfoReqExample": "Sélectionnez le ou les types d’informations demandées.",
   "landingPage.fullReport.button": "Commencer un rapport complet",
   "landingPage.fullReport.description": "Signalez un incident ayant eu des répercussions sur vous, une connaissance ou une entreprise.",
-  "landingPage.fyiReport.button": "Soumettre un renseignemen",
+  "landingPage.fyiReport.button": "Soumettre un renseignement",
   "landingPage.fyiReport.description": "Fournissez des informations générales sur une fraude ou un crime informatique.",
   "landingPage.intro": "Votre signalement aidera la <0>Gendarmerie royale du Canada</0> et le <1>Centre antifraude du Canada</1> à en apprendre plus sur ces types d’incidents.",
   "landingPage.reportOnline": "Signaler en ligne",


### PR DESCRIPTION
Fixes #2438 (issue)

# Description
It was found in the FYI button title change, French translation got error due to copy/paste from TEAM

It is now
Submit a general tip - Soumettre un renseignemen

It should be
Submit a general tip - Soumettre un renseignement

> Please include a summary of the change.
Cypress is also updated

# Any new packages installed?

> Give details

# Required followup work

> Is there anything related to this that still needs to be done (ex: documentation changes).

# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [ X] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
