### PR TITLE
Solve wrong personal ino title in PDF

### DIFF
--- a/f2/src/pdf/InformationView.js
+++ b/f2/src/pdf/InformationView.js
@@ -45,7 +45,7 @@ export const InformationView = (props) => {
   return (
     <View style={pdfStyles.section}>
       <Text style={pdfStyles.title}>
-        {lang['confirmationPage.contactTitle']}
+        {lang['confirmationPage.personalInformation.title']}
       </Text>
       {containsData(personalInformation) ? (
         <View>


### PR DESCRIPTION
Fixes #2394 (issue)

# Description
This is to fix wrong title at Personal Information in PDF

> Please include a summary of the change.

# Any new packages installed?

> Give details

# Required followup work

> Is there anything related to this that still needs to be done (ex: documentation changes).

# Checklist:

- [ ] I have updated the azurescript.sh with any **new environment variables** and added them to the appsettings
- [X ] I have looked at my code on GitHub and it all looks good (ex: no random commented out code or console.logs)
- [ ] I have added and needed tests for my changes (in particular for new screens)
- [ ] I have added a comment to any confusing code
- [ ] I have added documentation to any modified front-end code. (Or added missing documentation)
